### PR TITLE
Fix openai import scope

### DIFF
--- a/llama_stack/providers/remote/inference/nvidia/openai_utils.py
+++ b/llama_stack/providers/remote/inference/nvidia/openai_utils.py
@@ -10,8 +10,12 @@ from typing import Any
 
 from openai import AsyncStream
 
-# NOTE: Avoid deep imports from openai.types.* to remain compatible across SDK versions.
-# We only need structural access (attributes) and not the concrete classes.
+# Keep concrete types but avoid overly deep paths
+from openai.types.completion import Completion as OpenAICompletion
+from openai.types.completion_choice import (
+    CompletionChoice as OpenAICompletionChoice,
+    Logprobs as OpenAICompletionLogprobs,
+)
 
 from llama_stack.apis.inference import (
     ChatCompletionRequest,
@@ -175,7 +179,7 @@ def convert_completion_request(
 
 
 def _convert_openai_completion_logprobs(
-    logprobs: Any | None,
+    logprobs: OpenAICompletionLogprobs | None,
 ) -> list[TokenLogProbs] | None:
     """
     Convert an OpenAI CompletionLogprobs into a list of TokenLogProbs.
@@ -187,7 +191,7 @@ def _convert_openai_completion_logprobs(
 
 
 def convert_openai_completion_choice(
-    choice: Any,
+    choice: OpenAICompletionChoice,
 ) -> CompletionResponse:
     """
     Convert an OpenAI Completion Choice into a CompletionResponse.
@@ -200,7 +204,7 @@ def convert_openai_completion_choice(
 
 
 async def convert_openai_completion_stream(
-    stream: AsyncStream[Any],
+    stream: AsyncStream[OpenAICompletion],
 ) -> AsyncGenerator[CompletionResponse, None]:
     """
     Convert a stream of OpenAI Completions into a stream

--- a/llama_stack/providers/remote/inference/nvidia/openai_utils.py
+++ b/llama_stack/providers/remote/inference/nvidia/openai_utils.py
@@ -9,11 +9,9 @@ from collections.abc import AsyncGenerator
 from typing import Any
 
 from openai import AsyncStream
-from openai.types.chat.chat_completion import (
-    Choice as OpenAIChoice,
-)
-from openai.types.completion import Completion as OpenAICompletion
-from openai.types.completion_choice import Logprobs as OpenAICompletionLogprobs
+
+# NOTE: Avoid deep imports from openai.types.* to remain compatible across SDK versions.
+# We only need structural access (attributes) and not the concrete classes.
 
 from llama_stack.apis.inference import (
     ChatCompletionRequest,
@@ -177,7 +175,7 @@ def convert_completion_request(
 
 
 def _convert_openai_completion_logprobs(
-    logprobs: OpenAICompletionLogprobs | None,
+    logprobs: Any | None,
 ) -> list[TokenLogProbs] | None:
     """
     Convert an OpenAI CompletionLogprobs into a list of TokenLogProbs.
@@ -189,7 +187,7 @@ def _convert_openai_completion_logprobs(
 
 
 def convert_openai_completion_choice(
-    choice: OpenAIChoice,
+    choice: Any,
 ) -> CompletionResponse:
     """
     Convert an OpenAI Completion Choice into a CompletionResponse.
@@ -202,7 +200,7 @@ def convert_openai_completion_choice(
 
 
 async def convert_openai_completion_stream(
-    stream: AsyncStream[OpenAICompletion],
+    stream: AsyncStream[Any],
 ) -> AsyncGenerator[CompletionResponse, None]:
     """
     Convert a stream of OpenAI Completions into a stream


### PR DESCRIPTION
# What does this PR do?
This PR resolves an `ImportError` in `llama_stack/providers/remote/inference/nvidia/openai_utils.py` by replacing deep `openai.types.*` imports with `Any` type hints. This improves compatibility with varying OpenAI SDK versions by relying on structural attribute access rather than specific internal class imports.
Closes #3072

## Test Plan
The changes are primarily to address import stability and do not alter functional behavior. Attempts to run the test suite were unsuccessful due to environment limitations (Python/pytest not available).

---
<a href="https://cursor.com/background-agent?bcId=bc-da957982-7622-4250-8ef9-71524b4a45e2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-da957982-7622-4250-8ef9-71524b4a45e2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

