### PR TITLE
feat: add type annotations to shared inference utilities

### DIFF
--- a/src/llama_stack/providers/utils/bedrock/client.py
+++ b/src/llama_stack/providers/utils/bedrock/client.py
@@ -5,9 +5,9 @@
 # the root directory of this source tree.
 
 
-import boto3
-from botocore.client import BaseClient
-from botocore.config import Config
+import boto3  # ty: ignore[unresolved-import]
+from botocore.client import BaseClient  # ty: ignore[unresolved-import]
+from botocore.config import Config  # ty: ignore[unresolved-import]
 
 from llama_stack.providers.utils.bedrock.config import BedrockBaseConfig
 from llama_stack.providers.utils.bedrock.refreshable_boto_session import (

--- a/src/llama_stack/providers/utils/bedrock/config.py
+++ b/src/llama_stack/providers/utils/bedrock/config.py
@@ -5,6 +5,7 @@
 # the root directory of this source tree.
 
 import os
+from typing import Any
 
 from pydantic import Field, SecretStr
 
@@ -62,5 +63,5 @@ class BedrockBaseConfig(RemoteInferenceProviderConfig):
     )
 
     @classmethod
-    def sample_run_config(cls, **kwargs):
+    def sample_run_config(cls, **kwargs: Any) -> dict[str, Any]:
         return {}

--- a/src/llama_stack/providers/utils/bedrock/refreshable_boto_session.py
+++ b/src/llama_stack/providers/utils/bedrock/refreshable_boto_session.py
@@ -8,9 +8,9 @@ import datetime
 from time import time
 from uuid import uuid4
 
-from boto3 import Session
-from botocore.credentials import RefreshableCredentials
-from botocore.session import get_session
+from boto3 import Session  # ty: ignore[unresolved-import]
+from botocore.credentials import RefreshableCredentials  # ty: ignore[unresolved-import]
+from botocore.session import get_session  # ty: ignore[unresolved-import]
 
 
 class RefreshableBotoSession:
@@ -26,11 +26,11 @@ class RefreshableBotoSession:
 
     def __init__(
         self,
-        region_name: str = None,
-        profile_name: str = None,
-        sts_arn: str = None,
-        session_name: str = None,
-        session_ttl: int = 30000,
+        region_name: str | None = None,
+        profile_name: str | None = None,
+        sts_arn: str | None = None,
+        session_name: str | None = None,
+        session_ttl: int | None = 30000,
     ):
         """
         Initialize `RefreshableBotoSession`
@@ -60,7 +60,7 @@ class RefreshableBotoSession:
         self.session_name = session_name or uuid4().hex
         self.session_ttl = session_ttl
 
-    def __get_session_credentials(self):
+    def __get_session_credentials(self) -> dict[str, str | None]:
         """
         Get session credentials
         """
@@ -87,7 +87,7 @@ class RefreshableBotoSession:
                 "access_key": session_credentials.access_key,
                 "secret_key": session_credentials.secret_key,
                 "token": session_credentials.token,
-                "expiry_time": datetime.datetime.fromtimestamp(time() + self.session_ttl, datetime.UTC).isoformat(),
+                "expiry_time": datetime.datetime.fromtimestamp(time() + (self.session_ttl or 30000), datetime.UTC).isoformat(),
             }
 
         return credentials

--- a/src/llama_stack/providers/utils/bedrock/refreshable_boto_session.py
+++ b/src/llama_stack/providers/utils/bedrock/refreshable_boto_session.py
@@ -87,7 +87,9 @@ class RefreshableBotoSession:
                 "access_key": session_credentials.access_key,
                 "secret_key": session_credentials.secret_key,
                 "token": session_credentials.token,
-                "expiry_time": datetime.datetime.fromtimestamp(time() + (self.session_ttl or 30000), datetime.UTC).isoformat(),
+                "expiry_time": datetime.datetime.fromtimestamp(
+                    time() + (self.session_ttl or 30000), datetime.UTC
+                ).isoformat(),
             }
 
         return credentials

--- a/src/llama_stack/providers/utils/common/data_schema_validator.py
+++ b/src/llama_stack/providers/utils/common/data_schema_validator.py
@@ -73,7 +73,7 @@ VALID_SCHEMAS_FOR_EVAL = [
 ]
 
 
-def get_valid_schemas(api_str: str):
+def get_valid_schemas(api_str: str) -> list[dict[str, Any]]:
     """Return the valid dataset schemas for the given API.
 
     Args:
@@ -93,7 +93,7 @@ def get_valid_schemas(api_str: str):
 def validate_dataset_schema(
     dataset_schema: dict[str, Any],
     expected_schemas: list[dict[str, Any]],
-):
+) -> None:
     """Validate that a dataset schema matches one of the expected schemas.
 
     Args:
@@ -107,7 +107,7 @@ def validate_dataset_schema(
 def validate_row_schema(
     input_row: dict[str, Any],
     expected_schemas: list[dict[str, Any]],
-):
+) -> None:
     """Validate that an input row contains keys from at least one expected schema.
 
     Args:

--- a/src/llama_stack/providers/utils/common/data_url.py
+++ b/src/llama_stack/providers/utils/common/data_url.py
@@ -7,7 +7,7 @@
 import re
 
 
-def parse_data_url(data_url: str):
+def parse_data_url(data_url: str) -> dict[str, str | bool | None]:
     """Parse a data URL into its component parts.
 
     Args:

--- a/src/llama_stack/providers/utils/inference/__init__.py
+++ b/src/llama_stack/providers/utils/inference/__init__.py
@@ -6,4 +6,6 @@
 
 from llama_stack.models.llama.sku_list import all_registered_models
 
-ALL_HUGGINGFACE_REPOS_TO_MODEL_DESCRIPTOR = {m.huggingface_repo: m.descriptor() for m in all_registered_models()}
+ALL_HUGGINGFACE_REPOS_TO_MODEL_DESCRIPTOR: dict[str, str] = {
+    m.huggingface_repo: m.descriptor() for m in all_registered_models() if m.huggingface_repo is not None
+}

--- a/src/llama_stack/providers/utils/inference/embedding_mixin.py
+++ b/src/llama_stack/providers/utils/inference/embedding_mixin.py
@@ -8,12 +8,12 @@ import asyncio
 import base64
 import platform
 import struct
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from llama_stack.log import get_logger
 
 if TYPE_CHECKING:
-    from sentence_transformers import SentenceTransformer
+    from sentence_transformers import SentenceTransformer  # ty: ignore[unresolved-import]
 
 from llama_stack_api import (
     ModelStore,
@@ -37,6 +37,7 @@ class SentenceTransformerEmbeddingMixin:
     """Mixin providing OpenAI-compatible embeddings via sentence-transformers models."""
 
     model_store: ModelStore
+    config: Any  # Provided by the concrete class that uses this mixin
 
     async def openai_embeddings(
         self,
@@ -98,8 +99,8 @@ class SentenceTransformerEmbeddingMixin:
             log.info(f"Loading sentence transformer for {model}...")
 
             def _load_model():
-                import torch
-                from sentence_transformers import SentenceTransformer
+                import torch  # ty: ignore[unresolved-import]
+                from sentence_transformers import SentenceTransformer  # ty: ignore[unresolved-import]
 
                 platform_name = platform.system()
                 if platform_name == DARWIN:

--- a/src/llama_stack/providers/utils/inference/inference_store.py
+++ b/src/llama_stack/providers/utils/inference/inference_store.py
@@ -56,7 +56,7 @@ class InferenceStore:
         self._max_write_queue_size: int = reference.max_write_queue_size
         self._num_writers: int = max(1, reference.num_writers)
 
-    async def initialize(self):
+    async def initialize(self) -> None:
         """Create the necessary tables if they don't exist."""
         base_store = sqlstore_impl(self.reference)
         self.sql_store = AuthorizedSqlStore(base_store, self.policy)

--- a/src/llama_stack/providers/utils/inference/model_registry.py
+++ b/src/llama_stack/providers/utils/inference/model_registry.py
@@ -298,23 +298,24 @@ class ModelRegistryHelper(ModelsProtocolPrivate):
         return False
 
     async def register_model(self, model: Model) -> Model:
+        model_provider_resource_id = model.provider_resource_id or ""
         # Check if model is supported in static configuration
-        supported_model_id = self.get_provider_model_id(model.provider_resource_id)
+        supported_model_id = self.get_provider_model_id(model_provider_resource_id)
 
         # If not found in static config, check if it's available dynamically from provider
         if not supported_model_id:
-            if await self.check_model_availability(model.provider_resource_id):
-                supported_model_id = model.provider_resource_id
+            if await self.check_model_availability(model_provider_resource_id):
+                supported_model_id = model_provider_resource_id
             else:
                 # note: we cannot provide a complete list of supported models without
                 #       getting a complete list from the provider, so we return "..."
                 all_supported_models = [*self.alias_to_provider_id_map.keys(), "..."]
-                raise UnsupportedModelError(model.provider_resource_id, all_supported_models)
+                raise UnsupportedModelError(model_provider_resource_id, all_supported_models)
 
         provider_resource_id = self.get_provider_model_id(model.model_id)
         if model.model_type == ModelType.embedding:
             # embedding models are always registered by their provider model id and does not need to be mapped to a llama model
-            provider_resource_id = model.provider_resource_id
+            provider_resource_id = model_provider_resource_id
         if provider_resource_id:
             if provider_resource_id != supported_model_id:  # be idempotent, only reject differences
                 raise ValueError(
@@ -323,11 +324,11 @@ class ModelRegistryHelper(ModelsProtocolPrivate):
         else:
             llama_model = model.metadata.get("llama_model")
             if llama_model:
-                existing_llama_model = self.get_llama_model(model.provider_resource_id)
+                existing_llama_model = self.get_llama_model(model_provider_resource_id)
                 if existing_llama_model:
                     if existing_llama_model != llama_model:
                         raise ValueError(
-                            f"Provider model id '{model.provider_resource_id}' is already registered to a different llama model: '{existing_llama_model}'"
+                            f"Provider model id '{model_provider_resource_id}' is already registered to a different llama model: '{existing_llama_model}'"
                         )
                 else:
                     if llama_model not in ALL_HUGGINGFACE_REPOS_TO_MODEL_DESCRIPTOR:
@@ -335,7 +336,7 @@ class ModelRegistryHelper(ModelsProtocolPrivate):
                             f"Invalid llama_model '{llama_model}' specified in metadata. "
                             f"Must be one of: {', '.join(ALL_HUGGINGFACE_REPOS_TO_MODEL_DESCRIPTOR.keys())}"
                         )
-                    self.provider_id_to_llama_model_map[model.provider_resource_id] = (
+                    self.provider_id_to_llama_model_map[model_provider_resource_id] = (
                         ALL_HUGGINGFACE_REPOS_TO_MODEL_DESCRIPTOR[llama_model]
                     )
 

--- a/src/llama_stack/providers/utils/inference/openai_compat.py
+++ b/src/llama_stack/providers/utils/inference/openai_compat.py
@@ -57,7 +57,7 @@ def convert_tooldef_to_openai_tool(
     return out
 
 
-async def prepare_openai_completion_params(**params):
+async def prepare_openai_completion_params(**params: Any) -> dict[str, Any]:
     """Prepare keyword arguments for OpenAI-compatible completion calls.
 
     Args:

--- a/src/llama_stack/providers/utils/inference/openai_mixin.py
+++ b/src/llama_stack/providers/utils/inference/openai_mixin.py
@@ -357,6 +357,7 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
         resp = await self.client.completions.create(**completion_kwargs)
 
         return await self._maybe_overwrite_id(resp, params.stream)
+
     async def openai_chat_completion(
         self,
         params: OpenAIChatCompletionRequestWithExtraBody,
@@ -429,6 +430,7 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
         resp = await self.client.chat.completions.create(**request_params)
 
         return await self._maybe_overwrite_id(resp, params.stream)
+
     async def openai_embeddings(
         self,
         params: OpenAIEmbeddingsRequestWithExtraBody,

--- a/src/llama_stack/providers/utils/inference/openai_mixin.py
+++ b/src/llama_stack/providers/utils/inference/openai_mixin.py
@@ -32,6 +32,7 @@ from llama_stack_api import (
     ModelType,
     OpenAIChatCompletion,
     OpenAIChatCompletionChunk,
+    OpenAIChatCompletionContentPartImageParam,
     OpenAIChatCompletionRequestWithExtraBody,
     OpenAICompletion,
     OpenAICompletionRequestWithExtraBody,
@@ -158,14 +159,14 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
         """
         if metadata := self.embedding_model_metadata.get(identifier):
             return Model(
-                provider_id=self.__provider_id__,  # type: ignore[attr-defined]
+                provider_id=self.__provider_id__,  # ty: ignore[unresolved-attribute]  # runtime-injected by routing table
                 provider_resource_id=identifier,
                 identifier=identifier,
                 model_type=ModelType.embedding,
                 metadata=metadata,
             )
         return Model(
-            provider_id=self.__provider_id__,  # type: ignore[attr-defined]
+            provider_id=self.__provider_id__,  # ty: ignore[unresolved-attribute]  # runtime-injected by routing table
             provider_resource_id=identifier,
             identifier=identifier,
             model_type=ModelType.llm,
@@ -290,11 +291,11 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
         :return: The provider-specific model ID (e.g., "gpt-4")
         """
         # self.model_store is injected by the distribution system at runtime
-        if not await self.model_store.has_model(model):  # type: ignore[attr-defined]
+        if not await self.model_store.has_model(model):  # ty: ignore[unresolved-attribute]  # runtime-injected by routing table
             return model
 
         # Look up the registered model to get the provider-specific model ID
-        model_obj: Model = await self.model_store.get_model(model)  # type: ignore[attr-defined]
+        model_obj: Model = await self.model_store.get_model(model)  # ty: ignore[unresolved-attribute]  # runtime-injected by routing table
         # provider_resource_id is str | None, but we expect it to be str for OpenAI calls
         if model_obj.provider_resource_id is None:
             raise ValueError(f"Model {model} has no provider_resource_id")
@@ -355,8 +356,7 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
             completion_kwargs["extra_body"] = extra_body
         resp = await self.client.completions.create(**completion_kwargs)
 
-        return await self._maybe_overwrite_id(resp, params.stream)  # type: ignore[no-any-return]
-
+        return await self._maybe_overwrite_id(resp, params.stream)
     async def openai_chat_completion(
         self,
         params: OpenAIChatCompletionRequestWithExtraBody,
@@ -379,7 +379,9 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
             async def _localize_image_url(m: OpenAIMessageParam) -> OpenAIMessageParam:
                 if isinstance(m.content, list):
                     for c in m.content:
-                        if c.type == "image_url" and c.image_url and c.image_url.url and "http" in c.image_url.url:
+                        if not isinstance(c, OpenAIChatCompletionContentPartImageParam):
+                            continue
+                        if c.image_url and c.image_url.url and "http" in c.image_url.url:
                             localize_result = await localize_image_content(c.image_url.url)
                             if localize_result is None:
                                 raise ValueError(
@@ -426,8 +428,7 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
             request_params["extra_body"] = extra_body
         resp = await self.client.chat.completions.create(**request_params)
 
-        return await self._maybe_overwrite_id(resp, params.stream)  # type: ignore[no-any-return]
-
+        return await self._maybe_overwrite_id(resp, params.stream)
     async def openai_embeddings(
         self,
         params: OpenAIEmbeddingsRequestWithExtraBody,
@@ -501,7 +502,7 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
             return model
 
         if not await self.check_model_availability(model.provider_model_id):
-            raise ValueError(f"Model {model.provider_model_id} is not available from provider {self.__provider_id__}")  # type: ignore[attr-defined]
+            raise ValueError(f"Model {model.provider_model_id} is not available from provider {self.__provider_id__}")  # ty: ignore[unresolved-attribute]  # runtime-injected
         return model
 
     async def unregister_model(self, model_id: str) -> None:
@@ -561,9 +562,9 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
         :return: True if the model is available dynamically or pre-registered, False otherwise.
         """
         # First check if the model is pre-registered in the model store
-        if hasattr(self, "model_store") and self.model_store:
-            qualified_model = f"{self.__provider_id__}/{model}"  # type: ignore[attr-defined]
-            if await self.model_store.has_model(qualified_model):
+        if hasattr(self, "model_store") and self.model_store:  # runtime-injected by routing table
+            qualified_model = f"{self.__provider_id__}/{model}"  # ty: ignore[unresolved-attribute]  # runtime-injected
+            if await self.model_store.has_model(qualified_model):  # ty: ignore[unresolved-attribute]  # runtime-injected
                 return True
 
         # Then check the provider's dynamic model cache
@@ -579,7 +580,7 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
     # e.g. model_store, which are not pydantic.
     #
 
-    def _filter_fields(self, **kwargs):
+    def _filter_fields(self, **kwargs: Any) -> dict[str, Any]:
         """Helper to exclude extra fields from serialization."""
         # Exclude any extra fields stored in __pydantic_extra__
         if hasattr(self, "__pydantic_extra__") and self.__pydantic_extra__:
@@ -590,12 +591,12 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
             kwargs["exclude"] = exclude
         return kwargs
 
-    def model_dump(self, **kwargs):
+    def model_dump(self, **kwargs: Any) -> dict[str, Any]:
         """Override to exclude extra fields from serialization."""
         kwargs = self._filter_fields(**kwargs)
         return super().model_dump(**kwargs)
 
-    def model_dump_json(self, **kwargs):
+    def model_dump_json(self, **kwargs: Any) -> str:
         """Override to exclude extra fields from JSON serialization."""
         kwargs = self._filter_fields(**kwargs)
         return super().model_dump_json(**kwargs)

--- a/src/llama_stack/providers/utils/inference/prompt_adapter.py
+++ b/src/llama_stack/providers/utils/inference/prompt_adapter.py
@@ -6,7 +6,6 @@
 
 import base64
 import re
-from typing import Any, Union
 
 import httpx
 
@@ -22,7 +21,14 @@ from llama_stack_api import (
 log = get_logger(name=__name__, category="providers::utils")
 
 
-ContentItem = Union[str, TextContentItem, ImageContentItem, OpenAIChatCompletionContentPartTextParam, OpenAIChatCompletionContentPartImageParam, OpenAIFile]
+ContentItem = (
+    str
+    | TextContentItem
+    | ImageContentItem
+    | OpenAIChatCompletionContentPartTextParam
+    | OpenAIChatCompletionContentPartImageParam
+    | OpenAIFile
+)
 
 
 def interleaved_content_as_str(

--- a/src/llama_stack/providers/utils/inference/prompt_adapter.py
+++ b/src/llama_stack/providers/utils/inference/prompt_adapter.py
@@ -6,7 +6,7 @@
 
 import base64
 import re
-from typing import Any
+from typing import Any, Union
 
 import httpx
 
@@ -22,8 +22,11 @@ from llama_stack_api import (
 log = get_logger(name=__name__, category="providers::utils")
 
 
+ContentItem = Union[str, TextContentItem, ImageContentItem, OpenAIChatCompletionContentPartTextParam, OpenAIChatCompletionContentPartImageParam, OpenAIFile]
+
+
 def interleaved_content_as_str(
-    content: Any,
+    content: str | ContentItem | list[ContentItem] | None,
     sep: str = " ",
 ) -> str:
     """Convert interleaved content items to a single string.
@@ -38,7 +41,7 @@ def interleaved_content_as_str(
     if content is None:
         return ""
 
-    def _process(c) -> str:
+    def _process(c: ContentItem) -> str:
         if isinstance(c, str):
             return c
         elif isinstance(c, TextContentItem) or isinstance(c, OpenAIChatCompletionContentPartTextParam):


### PR DESCRIPTION
## Summary
- Adds type annotations to all 11 files in scope for issue #13 (shared inference utilities)
- All files pass `ty check` with zero errors
- All related unit tests pass (143 tests)

## Changes
- **openai_mixin.py**: Return types for `_filter_fields`, `model_dump`, `model_dump_json`; `isinstance` narrowing for image content union types; `ty: ignore[unresolved-attribute]` with rule codes for runtime-injected `__provider_id__` and `model_store`
- **openai_compat.py**: Parameter/return types for `prepare_openai_completion_params`
- **prompt_adapter.py**: `ContentItem` union type alias; typed `content` parameter and `_process` inner function
- **embedding_mixin.py**: Declared `config` attribute; `ty: ignore` for `sentence_transformers`/`torch` imports
- **model_registry.py**: Guarded `None` `provider_resource_id` with fallback to empty string
- **inference_store.py**: Return type for `initialize`
- **bedrock/**: `ty: ignore[unresolved-import]` for boto3/botocore; fixed `str` → `str | None` params; return type for `sample_run_config`
- **common/**: Return types for `parse_data_url`, `get_valid_schemas`, `validate_dataset_schema`, `validate_row_schema`
- **inference/__init__.py**: Filtered `None` keys from `ALL_HUGGINGFACE_REPOS_TO_MODEL_DESCRIPTOR`, added `dict[str, str]` annotation

## Test plan
- [x] `ty check` passes with zero errors on all 11 in-scope files
- [x] `uv run pytest tests/unit/providers/utils/inference/ -x` — 138 passed, 3 skipped
- [x] `uv run pytest tests/unit/providers/utils/test_openai_mixin_streaming.py` — 5 passed

## Build times
- ty check: 0.26s
- pytest (inference utils): 2.39s

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)