### PR TITLE
feat: add type annotations to core server lifecycle

### DIFF
--- a/src/llama_stack/core/admin.py
+++ b/src/llama_stack/core/admin.py
@@ -44,7 +44,7 @@ class AdminImplConfig(BaseModel):
     config: StackConfig
 
 
-async def get_provider_impl(config, deps):
+async def get_provider_impl(config: AdminImplConfig, deps: dict[Api, Any]) -> "AdminImpl":
     """Create and initialize an AdminImpl instance.
 
     Args:
@@ -62,7 +62,7 @@ async def get_provider_impl(config, deps):
 class AdminImpl(Admin):
     """Implementation of the Admin API providing provider management, route listing, health, and version endpoints."""
 
-    def __init__(self, config: AdminImplConfig, deps):
+    def __init__(self, config: AdminImplConfig, deps: dict[Api, Any]) -> None:
         self.config = config
         self.deps = deps
 

--- a/src/llama_stack/core/client.py
+++ b/src/llama_stack/core/client.py
@@ -17,10 +17,10 @@ from termcolor import cprint
 
 from llama_stack_api import RemoteProviderConfig
 
-_CLIENT_CLASSES = {}
+_CLIENT_CLASSES: dict[type, type] = {}
 
 
-async def get_client_impl(protocol, config: RemoteProviderConfig, _deps: Any):
+async def get_client_impl(protocol: type, config: RemoteProviderConfig, _deps: Any) -> Any:
     """Create and initialize an API client for a remote provider.
 
     Args:
@@ -37,7 +37,7 @@ async def get_client_impl(protocol, config: RemoteProviderConfig, _deps: Any):
     return impl
 
 
-def create_api_client_class(protocol) -> type:
+def create_api_client_class(protocol: type) -> type:
     """Dynamically create an API client class for the given protocol.
 
     Args:
@@ -203,7 +203,7 @@ def create_api_client_class(protocol) -> type:
     return APIClient
 
 
-def extract_non_async_iterator_type(type_hint):
+def extract_non_async_iterator_type(type_hint: Any) -> Any:
     """Extract the non-AsyncIterator type from a Union type hint.
 
     Args:
@@ -220,7 +220,7 @@ def extract_non_async_iterator_type(type_hint):
     return type_hint
 
 
-def extract_async_iterator_type(type_hint):
+def extract_async_iterator_type(type_hint: Any) -> Any:
     """Extract the inner type from an AsyncIterator within a Union type hint.
 
     Args:

--- a/src/llama_stack/core/inspect.py
+++ b/src/llama_stack/core/inspect.py
@@ -17,6 +17,8 @@ from llama_stack.core.server.fastapi_router_registry import (
     get_router_routes,
 )
 from llama_stack.core.server.routes import get_all_api_routes
+from typing import Any
+
 from llama_stack_api import (
     Api,
     HealthInfo,
@@ -34,7 +36,7 @@ class DistributionInspectConfig(BaseModel):
     config: StackConfig
 
 
-async def get_provider_impl(config, deps):
+async def get_provider_impl(config: DistributionInspectConfig, deps: dict[Api, Any]) -> "DistributionInspectImpl":
     """Create and initialize a DistributionInspectImpl instance.
 
     Args:
@@ -52,7 +54,7 @@ async def get_provider_impl(config, deps):
 class DistributionInspectImpl(Inspect):
     """Implementation of the Inspect API providing route listing, health, and version endpoints."""
 
-    def __init__(self, config: DistributionInspectConfig, deps):
+    def __init__(self, config: DistributionInspectConfig, deps: dict[Api, Any]) -> None:
         self.stack_config = config.config
         self.deps = deps
 

--- a/src/llama_stack/core/inspect.py
+++ b/src/llama_stack/core/inspect.py
@@ -5,6 +5,7 @@
 # the root directory of this source tree.
 
 from importlib.metadata import version
+from typing import Any
 
 from pydantic import BaseModel
 
@@ -17,8 +18,6 @@ from llama_stack.core.server.fastapi_router_registry import (
     get_router_routes,
 )
 from llama_stack.core.server.routes import get_all_api_routes
-from typing import Any
-
 from llama_stack_api import (
     Api,
     HealthInfo,

--- a/src/llama_stack/core/providers.py
+++ b/src/llama_stack/core/providers.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 
 from llama_stack.log import get_logger
 from llama_stack_api import (
+    Api,
     HealthResponse,
     HealthStatus,
     InspectProviderRequest,
@@ -31,7 +32,7 @@ class ProviderImplConfig(BaseModel):
     config: StackConfig
 
 
-async def get_provider_impl(config, deps):
+async def get_provider_impl(config: ProviderImplConfig, deps: dict[Api, Any]) -> "ProviderImpl":
     """Create and initialize a ProviderImpl instance.
 
     Args:
@@ -49,7 +50,7 @@ async def get_provider_impl(config, deps):
 class ProviderImpl(Providers):
     """Implementation of the Providers API for listing and inspecting configured providers."""
 
-    def __init__(self, config, deps):
+    def __init__(self, config: ProviderImplConfig, deps: dict[Api, Any]) -> None:
         self.stack_config = config.config
         self.deps = deps
 

--- a/src/llama_stack/core/stack.py
+++ b/src/llama_stack/core/stack.py
@@ -123,9 +123,9 @@ RESOURCES = [
 ]
 
 
-REGISTRY_REFRESH_INTERVAL_SECONDS = 300
-REGISTRY_REFRESH_TASK = None
-TEST_RECORDING_CONTEXT = None
+REGISTRY_REFRESH_INTERVAL_SECONDS: int = 300
+REGISTRY_REFRESH_TASK: asyncio.Task[None] | None = None
+TEST_RECORDING_CONTEXT: Any = None
 
 # ID fields for registered resources that should trigger skipping
 # when they resolve to empty/None (from conditional env vars like :+)
@@ -660,7 +660,7 @@ def cast_distro_name_to_string(config_dict: dict[str, Any]) -> dict[str, Any]:
     return config_dict
 
 
-def add_internal_implementations(impls: dict[Api, Any], config: StackConfig, policy: list) -> None:
+def add_internal_implementations(impls: dict[Api, Any], config: StackConfig, policy: list[Any]) -> None:
     """Add internal implementations (inspect, providers, admin, etc.) to the implementations dictionary."""
     inspect_impl = DistributionInspectImpl(
         DistributionInspectConfig(config=config),
@@ -698,7 +698,7 @@ def add_internal_implementations(impls: dict[Api, Any], config: StackConfig, pol
     impls[Api.connectors] = connectors_impl
 
 
-def _initialize_storage(run_config: StackConfig):
+def _initialize_storage(run_config: StackConfig) -> None:
     kv_backends: dict[str, StorageBackendConfig] = {}
     sql_backends: dict[str, StorageBackendConfig] = {}
     for backend_name, backend_config in run_config.storage.backends.items():
@@ -723,11 +723,11 @@ class Stack:
     def __init__(self, run_config: StackConfig, provider_registry: ProviderRegistry | None = None):
         self.run_config = run_config
         self.provider_registry = provider_registry
-        self.impls = None
+        self.impls: dict[Api, Any] | None = None
 
     # Produces a stack of providers for the given run config. Not all APIs may be
     # asked for in the run config.
-    async def initialize(self):
+    async def initialize(self) -> None:
         if "LLAMA_STACK_TEST_INFERENCE_MODE" in os.environ:
             from llama_stack.testing.api_recorder import setup_api_recording
 
@@ -744,7 +744,7 @@ class Stack:
         dist_registry, _ = await create_dist_registry(stores.metadata, self.run_config.distro_name)
         policy = self.run_config.server.auth.access_policy if self.run_config.server.auth else []
 
-        internal_impls = {}
+        internal_impls: dict[Api, Any] = {}
         add_internal_implementations(internal_impls, self.run_config, policy)
 
         impls = await resolve_impls(
@@ -770,13 +770,13 @@ class Stack:
         await validate_safety_config(self.run_config.safety, impls)
         self.impls = impls
 
-    def create_registry_refresh_task(self):
+    def create_registry_refresh_task(self) -> None:
         assert self.impls is not None, "Must call initialize() before starting"
 
         global REGISTRY_REFRESH_TASK
         REGISTRY_REFRESH_TASK = asyncio.create_task(refresh_registry_task(self.impls))
 
-        def cb(task):
+        def cb(task: asyncio.Task[None]) -> None:
             import traceback
 
             if task.cancelled():
@@ -789,7 +789,7 @@ class Stack:
 
         REGISTRY_REFRESH_TASK.add_done_callback(cb)
 
-    async def shutdown(self):
+    async def shutdown(self) -> None:
         for impl in self.impls.values():
             impl_name = impl.__class__.__name__
             logger.debug("Shutting down", impl_name=impl_name)
@@ -829,7 +829,7 @@ class Stack:
             logger.exception("Failed to shutdown SQL store backends", error=str(e))
 
 
-async def refresh_registry_once(impls: dict[Api, Any]):
+async def refresh_registry_once(impls: dict[Api, Any]) -> None:
     """Refresh all routing table registries once by calling their refresh methods."""
     logger.debug("refreshing registry")
     routing_tables = [v for v in impls.values() if isinstance(v, CommonRoutingTableImpl)]
@@ -837,7 +837,7 @@ async def refresh_registry_once(impls: dict[Api, Any]):
         await routing_table.refresh()
 
 
-async def refresh_registry_task(impls: dict[Api, Any]):
+async def refresh_registry_task(impls: dict[Api, Any]) -> None:
     """Background task that periodically refreshes routing table registries."""
     logger.info("starting registry refresh task")
     while True:

--- a/src/llama_stack/core/task.py
+++ b/src/llama_stack/core/task.py
@@ -5,7 +5,7 @@
 # the root directory of this source tree.
 
 import asyncio
-from collections.abc import Coroutine
+from collections.abc import Coroutine, Generator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any
@@ -40,7 +40,7 @@ def capture_request_context() -> RequestContext:
 
 
 @contextmanager
-def activate_request_context(ctx: RequestContext):
+def activate_request_context(ctx: RequestContext) -> Generator[None, None, None]:
     """Temporarily restore a previously captured request context.
 
     Use this in worker loops that run with a detached (empty) context to

--- a/src/llama_stack/core/testing_context.py
+++ b/src/llama_stack/core/testing_context.py
@@ -5,7 +5,7 @@
 # the root directory of this source tree.
 
 import os
-from contextvars import ContextVar
+from contextvars import ContextVar, Token
 
 from llama_stack.core.request_headers import PROVIDER_DATA_VAR
 
@@ -21,7 +21,7 @@ def get_test_context() -> str | None:
     return TEST_CONTEXT.get()
 
 
-def set_test_context(value: str | None):
+def set_test_context(value: str | None) -> Token[str | None]:
     """Set the test context identifier for the current async context.
 
     Args:
@@ -33,7 +33,7 @@ def set_test_context(value: str | None):
     return TEST_CONTEXT.set(value)
 
 
-def reset_test_context(token) -> None:
+def reset_test_context(token: Token[str | None]) -> None:
     """Reset the test context to its previous value using a token from set_test_context.
 
     Args:
@@ -42,7 +42,7 @@ def reset_test_context(token) -> None:
     TEST_CONTEXT.reset(token)
 
 
-def sync_test_context_from_provider_data():
+def sync_test_context_from_provider_data() -> Token[str | None] | None:
     """Sync test context from provider data when running in server test mode."""
     if "LLAMA_STACK_TEST_INFERENCE_MODE" not in os.environ:
         return None

--- a/src/llama_stack/core/utils/dynamic.py
+++ b/src/llama_stack/core/utils/dynamic.py
@@ -5,9 +5,10 @@
 # the root directory of this source tree.
 
 import importlib
+from typing import Any
 
 
-def instantiate_class_type(fully_qualified_name):
+def instantiate_class_type(fully_qualified_name: str) -> Any:
     """Import and return a class from its fully qualified module path.
 
     Args:

--- a/src/llama_stack/core/utils/exec.py
+++ b/src/llama_stack/core/utils/exec.py
@@ -9,7 +9,6 @@ import os
 import signal
 import subprocess
 import sys
-
 from typing import Any
 
 from termcolor import cprint

--- a/src/llama_stack/core/utils/exec.py
+++ b/src/llama_stack/core/utils/exec.py
@@ -10,6 +10,8 @@ import signal
 import subprocess
 import sys
 
+from typing import Any
+
 from termcolor import cprint
 
 from llama_stack.log import get_logger
@@ -17,7 +19,7 @@ from llama_stack.log import get_logger
 log = get_logger(name=__name__, category="core")
 
 
-def formulate_run_args(image_type: str, distro_name: str) -> list:
+def formulate_run_args(image_type: str, distro_name: str) -> list[Any]:
     """Build the command-line arguments for starting a Llama Stack server.
 
     Args:
@@ -50,7 +52,7 @@ def formulate_run_args(image_type: str, distro_name: str) -> list:
     return run_args
 
 
-def in_notebook():
+def in_notebook() -> bool:
     """Detect whether the current code is running inside a Jupyter notebook.
 
     Returns:

--- a/src/llama_stack/core/utils/prompt_for_config.py
+++ b/src/llama_stack/core/utils/prompt_for_config.py
@@ -18,7 +18,7 @@ from llama_stack.log import get_logger
 log = get_logger(name=__name__, category="core")
 
 
-def is_list_of_primitives(field_type):
+def is_list_of_primitives(field_type: Any) -> bool:
     """Check if a field type is a List of primitive types."""
     origin = get_origin(field_type)
     if origin is list or origin is list:
@@ -28,7 +28,7 @@ def is_list_of_primitives(field_type):
     return False
 
 
-def is_basemodel_without_fields(typ):
+def is_basemodel_without_fields(typ: Any) -> bool:
     """Check if a type is a Pydantic BaseModel subclass with no defined fields.
 
     Args:
@@ -40,7 +40,7 @@ def is_basemodel_without_fields(typ):
     return inspect.isclass(typ) and issubclass(typ, BaseModel) and len(typ.__fields__) == 0
 
 
-def can_recurse(typ):
+def can_recurse(typ: Any) -> bool:
     """Check if a type is a Pydantic BaseModel subclass with fields that can be recursively prompted.
 
     Args:
@@ -52,19 +52,19 @@ def can_recurse(typ):
     return inspect.isclass(typ) and issubclass(typ, BaseModel) and len(typ.__fields__) > 0
 
 
-def get_literal_values(field):
+def get_literal_values(field: FieldInfo) -> tuple[Any, ...] | None:
     """Extract literal values from a field if it's a Literal type."""
     if get_origin(field.annotation) is Literal:
         return get_args(field.annotation)
     return None
 
 
-def is_optional(field_type):
+def is_optional(field_type: Any) -> bool:
     """Check if a field type is Optional."""
     return get_origin(field_type) is Union and type(None) in get_args(field_type)
 
 
-def get_non_none_type(field_type):
+def get_non_none_type(field_type: Any) -> Any:
     """Get the non-None type from an Optional type."""
     return next(arg for arg in get_args(field_type) if arg is not type(None))
 
@@ -88,7 +88,7 @@ def manually_validate_field(model: type[BaseModel], field_name: str, value: Any)
     return value
 
 
-def is_discriminated_union(typ) -> bool:
+def is_discriminated_union(typ: Any) -> bool:
     """Check if a type or FieldInfo represents a discriminated union.
 
     Args:
@@ -107,10 +107,10 @@ def is_discriminated_union(typ) -> bool:
 
 
 def prompt_for_discriminated_union(
-    field_name,
-    typ,
-    existing_value,
-):
+    field_name: str,
+    typ: Any,
+    existing_value: BaseModel | None,
+) -> BaseModel:
     """Interactively prompt the user to select and configure a discriminated union variant.
 
     Args:

--- a/src/llama_stack/core/utils/serialize.py
+++ b/src/llama_stack/core/utils/serialize.py
@@ -7,12 +7,13 @@
 import json
 from datetime import datetime
 from enum import Enum
+from typing import Any
 
 
 class EnumEncoder(json.JSONEncoder):
     """JSON encoder that serializes Enum values and datetime objects."""
 
-    def default(self, obj):
+    def default(self, obj: Any) -> Any:
         if isinstance(obj, Enum):
             return obj.value
         elif isinstance(obj, datetime):

--- a/src/llama_stack/telemetry/__init__.py
+++ b/src/llama_stack/telemetry/__init__.py
@@ -17,7 +17,7 @@ from llama_stack.log import get_logger
 logger = get_logger(__name__, category="telemetry")
 
 
-def setup_telemetry():
+def setup_telemetry() -> None:
     """Initialize OpenTelemetry metrics exporter if configured via environment.
 
     This function checks for OTEL_EXPORTER_OTLP_ENDPOINT and configures the


### PR DESCRIPTION
## Summary
- Added parameter and return type annotations to all `get_provider_impl()` factory functions in core modules (admin, inspect, providers)
- Added type annotations to class constructors (`__init__`) for `AdminImpl`, `DistributionInspectImpl`, `ProviderImpl`
- Fixed loose annotations in `stack.py` (module-level variables, `Stack.initialize`, `Stack.shutdown`, callback types)
- Added proper return types to utility functions in `exec.py`, `serialize.py`, `dynamic.py`, `prompt_for_config.py`
- Added `Token` type annotations to `testing_context.py` for `set_test_context` / `reset_test_context`
- Added `Generator` return type to `activate_request_context` in `task.py`
- Added return type to `setup_telemetry()` in `telemetry/__init__.py`

## Files changed (14)
- `src/llama_stack/core/admin.py` - typed `get_provider_impl`, `__init__`
- `src/llama_stack/core/client.py` - typed `get_client_impl`, `create_api_client_class`, extract functions, `_CLIENT_CLASSES`
- `src/llama_stack/core/inspect.py` - typed `get_provider_impl`, `__init__`
- `src/llama_stack/core/providers.py` - typed `get_provider_impl`, `__init__`
- `src/llama_stack/core/stack.py` - typed module variables, `Stack` methods, `add_internal_implementations`, internal callbacks
- `src/llama_stack/core/store/registry.py` - already well-typed (no changes needed)
- `src/llama_stack/core/task.py` - added `Generator` return type to `activate_request_context`
- `src/llama_stack/core/testing_context.py` - typed `Token` params/returns
- `src/llama_stack/core/utils/dynamic.py` - typed `instantiate_class_type`
- `src/llama_stack/core/utils/exec.py` - typed `formulate_run_args`, `in_notebook`
- `src/llama_stack/core/utils/prompt_for_config.py` - typed all helper functions
- `src/llama_stack/core/utils/serialize.py` - typed `EnumEncoder.default`
- `src/llama_stack/telemetry/__init__.py` - typed `setup_telemetry`

## Test plan
- [x] `uv run pytest tests/unit/ -x --tb=short` — 1647 tests pass, 3 skipped
- [x] No runtime behavior changes — annotation-only modifications
- [x] Uses `X | None` not `Optional[X]`
- [x] No bare `# type: ignore` added

🤖 Generated with [Claude Code](https://claude.com/claude-code)