### PR TITLE
fix: add type: ignore for runtime-injected attributes

### DIFF
--- a/src/llama_stack/core/routing_tables/common.py
+++ b/src/llama_stack/core/routing_tables/common.py
@@ -131,21 +131,21 @@ class CommonRoutingTableImpl(RoutingTable):
         for pid, p in self.impls_by_provider_id.items():
             api = get_impl_api(p)
             if api == Api.inference:
-                p.model_store = self
+                p.model_store = self  # type: ignore[attr-defined]  # runtime-injected, declared on OpenAIMixin
             elif api == Api.safety:
-                p.shield_store = self
+                p.shield_store = self  # type: ignore[attr-defined]  # runtime-injected
             elif api == Api.vector_io:
-                p.vector_store_store = self
+                p.vector_store_store = self  # type: ignore[attr-defined]  # runtime-injected
             elif api == Api.datasetio:
-                p.dataset_store = self
+                p.dataset_store = self  # type: ignore[attr-defined]  # runtime-injected
             elif api == Api.scoring:
-                p.scoring_function_store = self
-                scoring_functions = await p.list_scoring_functions()
+                p.scoring_function_store = self  # type: ignore[attr-defined]  # runtime-injected
+                scoring_functions = await p.list_scoring_functions()  # type: ignore[attr-defined]  # runtime-injected
                 await add_objects(scoring_functions, pid, ScoringFnWithOwner)
             elif api == Api.eval:
-                p.benchmark_store = self
+                p.benchmark_store = self  # type: ignore[attr-defined]  # runtime-injected
             elif api == Api.tool_runtime:
-                p.tool_store = self
+                p.tool_store = self  # type: ignore[attr-defined]  # runtime-injected
 
     async def shutdown(self) -> None:
         for p in self.impls_by_provider_id.values():


### PR DESCRIPTION
## Summary
- Adds targeted `# type: ignore[attr-defined]` comments to runtime-injected store attributes in `CommonRoutingTableImpl.initialize()`
- These attributes (`model_store`, `shield_store`, `vector_store_store`, etc.) are set on `RoutedProtocol` instances at runtime but are not part of the protocol type
- Without these annotations, `ty check` flags all 8 assignments as errors

## Context
Follow-up to PR #25 which added type annotations to the routing dispatch layer but missed the `type: ignore` comments for the runtime attribute injections.

## Test plan
- [x] `uv run pytest tests/unit/ -q` — 1110 tests pass
- [x] `uv run ruff check` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)