### PR TITLE
style: fix line length in routing_tables/common.py

### DIFF
--- a/src/llama_stack/core/routing_tables/common.py
+++ b/src/llama_stack/core/routing_tables/common.py
@@ -116,7 +116,9 @@ class CommonRoutingTableImpl(RoutingTable):
         self.policy = policy
 
     async def initialize(self) -> None:
-        async def add_objects(objs: list[RoutableObjectWithProvider], provider_id: str, cls: type[RoutableObjectWithProvider] | None) -> None:
+        async def add_objects(
+            objs: list[RoutableObjectWithProvider], provider_id: str, cls: type[RoutableObjectWithProvider] | None
+        ) -> None:
             for obj in objs:
                 if cls is None:
                     obj.provider_id = provider_id


### PR DESCRIPTION
## Summary
- Fix ruff format violation introduced in PR #25/#30 where the `add_objects` function signature exceeded the line length limit after type annotations were added

## Test plan
- [x] `uv run ruff format --check` passes
- [x] No behavioral changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)