### PR TITLE
fix: resolve remaining ty check errors in core lifecycle (Issue #11)

### DIFF
--- a/src/llama_stack/core/client.py
+++ b/src/llama_stack/core/client.py
@@ -95,6 +95,7 @@ def create_api_client_class(protocol: type) -> type:
                 if j is None:
                     return None
                 # print(f"({protocol.__name__}) Returning {j}, type {return_type}")
+                assert return_type is not None
                 return parse_obj_as(return_type, j)
 
         async def _call_streaming(self, method_name: str, *args, **kwargs) -> Any:
@@ -194,7 +195,7 @@ def create_api_client_class(protocol: type) -> type:
 
             method_impl.__name__ = name
             method_impl.__qualname__ = f"APIClient.{name}"
-            method_impl.__signature__ = inspect.signature(method)
+            setattr(method_impl, "__signature__", inspect.signature(method))
             setattr(APIClient, name, method_impl)
 
     # Name the class after the protocol

--- a/src/llama_stack/core/stack.py
+++ b/src/llama_stack/core/stack.py
@@ -11,7 +11,7 @@ import os
 import re
 import tempfile
 from pathlib import Path
-from typing import Any, get_type_hints
+from typing import Any, cast, get_type_hints
 
 import yaml
 from pydantic import BaseModel
@@ -520,12 +520,13 @@ def replace_env_vars(config: Any, path: str = "") -> Any:
                 # Special handling for providers: first resolve the provider_id to check if provider
                 # is disabled so that we can skip config env variable expansion and avoid validation errors
                 if isinstance(v, dict) and "provider_id" in v:
+                    vd = cast(dict[str, Any], v)
                     try:
-                        resolved_provider_id = replace_env_vars(v["provider_id"], f"{path}[{i}].provider_id")
+                        resolved_provider_id = replace_env_vars(vd["provider_id"], f"{path}[{i}].provider_id")
                         if resolved_provider_id == "__disabled__":
                             logger.debug(
                                 "Skipping config env variable expansion for disabled provider",
-                                v_get_provider_id=v.get("provider_id", ""),
+                                v_get_provider_id=vd.get("provider_id", ""),
                             )
                             continue
                     except EnvVarError:
@@ -535,11 +536,12 @@ def replace_env_vars(config: Any, path: str = "") -> Any:
                 # Special handling for registered resources: check if ID field resolves to empty/None
                 # from conditional env vars (e.g., ${env.VAR:+value}) and skip the entry if so
                 if isinstance(v, dict):
+                    vd2 = cast(dict[str, Any], v)
                     should_skip = False
                     for id_field in RESOURCE_ID_FIELDS:
-                        if id_field in v:
+                        if id_field in vd2:
                             try:
-                                resolved_id = replace_env_vars(v[id_field], f"{path}[{i}].{id_field}")
+                                resolved_id = replace_env_vars(vd2[id_field], f"{path}[{i}].{id_field}")
                                 if resolved_id is None or resolved_id == "":
                                     logger.debug(
                                         "Skipping [] with empty (conditional env var not set)",
@@ -741,6 +743,7 @@ class Stack:
         stores = self.run_config.storage.stores
         if not stores.metadata:
             raise ValueError("storage.stores.metadata must be configured with a kv_* backend")
+        assert self.run_config.distro_name is not None, "distro_name must be set"
         dist_registry, _ = await create_dist_registry(stores.metadata, self.run_config.distro_name)
         policy = self.run_config.server.auth.access_policy if self.run_config.server.auth else []
 
@@ -790,6 +793,8 @@ class Stack:
         REGISTRY_REFRESH_TASK.add_done_callback(cb)
 
     async def shutdown(self) -> None:
+        if self.impls is None:
+            return
         for impl in self.impls.values():
             impl_name = impl.__class__.__name__
             logger.debug("Shutting down", impl_name=impl_name)

--- a/src/llama_stack/core/utils/context.py
+++ b/src/llama_stack/core/utils/context.py
@@ -6,6 +6,7 @@
 
 from collections.abc import AsyncGenerator
 from contextvars import ContextVar
+from typing import Any
 
 _MISSING = object()
 
@@ -23,8 +24,8 @@ def preserve_contexts_async_generator[T](
 
     async def wrapper() -> AsyncGenerator[T, None]:
         while True:
-            previous_values: dict[ContextVar, object] = {}
-            tokens: dict[ContextVar, object] = {}
+            previous_values: dict[ContextVar[Any], object] = {}
+            tokens: dict[ContextVar[Any], Any] = {}
 
             # Restore ALL context values before any await and capture previous state
             # This is needed to propagate context across async generator boundaries

--- a/src/llama_stack/core/utils/prompt_for_config.py
+++ b/src/llama_stack/core/utils/prompt_for_config.py
@@ -7,7 +7,7 @@
 import inspect
 import json
 from enum import Enum
-from typing import Annotated, Any, Literal, Union, get_args, get_origin
+from typing import Annotated, Any, Literal, Union, cast, get_args, get_origin
 
 from pydantic import BaseModel
 from pydantic.fields import FieldInfo
@@ -183,7 +183,7 @@ def prompt_for_config(config_type: type[BaseModel], existing_config: BaseModel |
     config_data = {}
 
     for field_name, field in config_type.__fields__.items():
-        field_type = field.annotation
+        field_type = cast(type, field.annotation)
         existing_value = getattr(existing_config, field_name) if existing_config else None
         if existing_value:
             default_value = existing_value
@@ -207,7 +207,7 @@ def prompt_for_config(config_type: type[BaseModel], existing_config: BaseModel |
                 user_input = input(prompt + " ")
                 try:
                     value = field_type[user_input]
-                    validated_value = manually_validate_field(config_type, field, value)
+                    validated_value = manually_validate_field(config_type, field_name, value)
                     config_data[field_name] = validated_value
                     break
                 except KeyError:
@@ -240,7 +240,7 @@ def prompt_for_config(config_type: type[BaseModel], existing_config: BaseModel |
         elif can_recurse(field_type):
             log.info(f"\nEntering sub-configuration for {field_name}:")
             config_data[field_name] = prompt_for_config(
-                field_type,
+                cast(type[BaseModel], field_type),
                 existing_value,
             )
         else:

--- a/src/llama_stack/core/utils/serialize.py
+++ b/src/llama_stack/core/utils/serialize.py
@@ -13,9 +13,9 @@ from typing import Any
 class EnumEncoder(json.JSONEncoder):
     """JSON encoder that serializes Enum values and datetime objects."""
 
-    def default(self, obj: Any) -> Any:
-        if isinstance(obj, Enum):
-            return obj.value
-        elif isinstance(obj, datetime):
-            return obj.isoformat()
-        return super().default(obj)
+    def default(self, o: Any) -> Any:
+        if isinstance(o, Enum):
+            return o.value
+        elif isinstance(o, datetime):
+            return o.isoformat()
+        return super().default(o)


### PR DESCRIPTION
## Summary
- Fix 13 remaining ty check errors in core server lifecycle files
- These were missed by PR #20 which did initial annotation work

## Changes
- **client.py**: Assert `return_type` not None before `parse_obj_as`, use `setattr` for `__signature__`
- **stack.py**: Use `cast(dict[str, Any], v)` for dict narrowing, assert `distro_name`, null-guard `shutdown`
- **context.py**: Use `Any`-parameterized `ContextVar` types for tokens dict
- **prompt_for_config.py**: `cast(type, field.annotation)`, fix `manually_validate_field` arg, `cast` for `prompt_for_config`
- **serialize.py**: Rename parameter `obj` → `o` to match `JSONEncoder.default` signature

## Test Plan
- [x] `ty check` passes with zero errors on all 14 core lifecycle files
- [x] 1110 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)