### PR TITLE
fix: remove redundant cast in core server lifecycle (#45)

### DIFF
--- a/src/llama_stack/core/server/fastapi_router_registry.py
+++ b/src/llama_stack/core/server/fastapi_router_registry.py
@@ -96,10 +96,7 @@ def build_fastapi_router(api: "Api", impl: Any) -> APIRouter | None:
     if router_factory is None:
         return None
 
-    # cast is safe here: all router factories in API packages are required to return APIRouter.
-    # If a router factory returns the wrong type, it will fail at runtime when
-    # app.include_router(router) is called
-    return cast(APIRouter, router_factory(impl))
+    return router_factory(impl)
 
 
 def get_router_routes(router: APIRouter) -> list[APIRoute]:


### PR DESCRIPTION
## Summary

- Remove unnecessary `cast(APIRouter, ...)` in `fastapi_router_registry.py` that ty flagged as `redundant-cast`
- `ty check src/llama_stack/core/server/` now passes with zero diagnostics

## Test plan

- [x] `ty check src/llama_stack/core/server/` → "All checks passed!"
- [x] `uv run pytest tests/unit/core/ -x --tb=short` → 233 passed (4.32s)

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)