### PR TITLE
fix: type-check shared inference HTTP client utilities (#46)

### DIFF
--- a/src/llama_stack/providers/utils/inference/http_client.py
+++ b/src/llama_stack/providers/utils/inference/http_client.py
@@ -151,7 +151,7 @@ def _extract_client_config(existing_client: httpx.AsyncClient | DefaultAsyncHttp
 
     # Extract from DefaultAsyncHttpxClient
     if isinstance(existing_client, DefaultAsyncHttpxClient):
-        underlying_client = existing_client._client  # type: ignore[union-attr,attr-defined]
+        underlying_client = existing_client._client  # ty: ignore[unresolved-attribute]  # accessing internal httpx client attribute
         if hasattr(underlying_client, "_auth"):
             config["auth"] = underlying_client._auth  # type: ignore[attr-defined]
         if hasattr(existing_client, "_headers"):
@@ -210,7 +210,7 @@ def _merge_network_config_into_client(
 
         # If original was DefaultAsyncHttpxClient, wrap the new client
         if isinstance(existing_client, DefaultAsyncHttpxClient):
-            return DefaultAsyncHttpxClient(client=new_client, headers=network_kwargs.get("headers"))  # type: ignore[call-arg]
+            return DefaultAsyncHttpxClient(client=new_client, headers=network_kwargs.get("headers"))  # ty: ignore[unknown-argument]  # passing internal client to DefaultAsyncHttpxClient
 
         return new_client
     except Exception as e:


### PR DESCRIPTION
## Summary
- Replace 2 mypy-style `# type: ignore` comments with ty-style `# ty: ignore[rule]` in `src/llama_stack/providers/utils/inference/http_client.py`
- `type: ignore[union-attr,attr-defined]` → `ty: ignore[unresolved-attribute]` (line 154)
- `type: ignore[call-arg]` → `ty: ignore[unknown-argument]` (line 213)

## Verification
- `ty check src/llama_stack/providers/utils/inference/` passes with zero errors
- 233 core unit tests pass

## Test plan
- [x] `ty check` passes on the file and directory
- [x] Unit tests pass (`pytest tests/unit/core/ -x`)

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)