### PR TITLE
fix: resolve remaining ty check errors in M6 safety/tool runtime

### DIFF
--- a/src/llama_stack/providers/inline/safety/prompt_guard/prompt_guard.py
+++ b/src/llama_stack/providers/inline/safety/prompt_guard/prompt_guard.py
@@ -42,8 +42,8 @@ class PromptGuardSafetyImpl(ShieldToModerationMixin, Safety, ShieldsProtocolPriv
 
     async def initialize(self) -> None:
         # Lazy import torch and transformers to reduce startup memory (~46MB+ savings)
-        import torch
-        from transformers import AutoModelForSequenceClassification, AutoTokenizer
+        import torch  # ty: ignore[unresolved-import]
+        from transformers import AutoModelForSequenceClassification, AutoTokenizer  # ty: ignore[unresolved-import]
 
         model_dir = model_local_dir(PROMPT_GUARD_MODEL)
         self.shield = PromptGuardShield(

--- a/src/llama_stack/providers/inline/tool_runtime/file_search/context_retriever.py
+++ b/src/llama_stack/providers/inline/tool_runtime/file_search/context_retriever.py
@@ -75,9 +75,9 @@ async def llm_rag_query_generator(
 
     messages = []
     if isinstance(content, list):
-        messages = [interleaved_content_as_str(m) for m in content]  # ty: ignore[invalid-argument-type]
+        messages = [interleaved_content_as_str(m) for m in content]
     else:
-        messages = [interleaved_content_as_str(content)]  # ty: ignore[invalid-argument-type]
+        messages = [interleaved_content_as_str(content)]
 
     template = Template(config.template)
     rendered_content: str = template.render({"messages": messages})
@@ -91,6 +91,6 @@ async def llm_rag_query_generator(
     )
     response = await inference_api.openai_chat_completion(params)
 
-    query = response.choices[0].message.content  # ty: ignore[unresolved-attribute]
+    query = response.choices[0].message.content
 
     return query

--- a/src/llama_stack/providers/inline/tool_runtime/file_search/file_search.py
+++ b/src/llama_stack/providers/inline/tool_runtime/file_search/file_search.py
@@ -65,7 +65,7 @@ async def raw_data_from_doc(doc: RAGDocument) -> tuple[bytes, str]:
             else:
                 file_data = str(data).encode("utf-8")
 
-            return file_data, mime_type
+            return file_data, str(mime_type)
         else:
             async with httpx.AsyncClient() as client:
                 r = await client.get(uri)
@@ -90,7 +90,7 @@ async def raw_data_from_doc(doc: RAGDocument) -> tuple[bytes, str]:
             else:
                 file_data = str(data).encode("utf-8")
 
-            return file_data, mime_type
+            return file_data, str(mime_type)
         else:
             return content_str.encode("utf-8"), "text/plain"
 
@@ -239,7 +239,7 @@ class FileSearchToolRuntimeImpl(ToolGroupsProtocolPrivate, ToolRuntime):
             return RAGQueryResult(content=None)
 
         # sort by score
-        chunks, scores = zip(*sorted(zip(chunks, scores, strict=False), key=lambda x: x[1], reverse=True), strict=False)  # type: ignore
+        chunks, scores = zip(*sorted(zip(chunks, scores, strict=False), key=lambda x: x[1], reverse=True), strict=False)
         chunks = chunks[: query_config.max_chunks]
 
         tokens = 0


### PR DESCRIPTION
## Summary

- Add `# ty: ignore[unresolved-import]` for `torch` and `transformers` imports in `prompt_guard.py` (optional deps not installed)
- Fix `invalid-return-type` in `file_search.py` by wrapping `mime_type` with `str()` (was `str | bool | None` from `parse_data_url`)
- Remove 3 unused `# ty: ignore` comments in `context_retriever.py` and 1 unused `# type: ignore` in `file_search.py`

After this PR, `ty check` on all M6 scopes passes with zero diagnostics.

## Test plan

- [x] `ty check src/llama_stack/providers/inline/safety/ src/llama_stack/providers/inline/tool_runtime/ src/llama_stack/providers/remote/safety/ src/llama_stack/providers/remote/tool_runtime/` → "All checks passed!"
- [x] `uv run pytest tests/unit/core/ -x --tb=short` → 233 passed

Closes remaining M6 errors from #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)