### PR TITLE
fix: add type annotations to remote inference providers

### DIFF
--- a/src/llama_stack/providers/remote/inference/bedrock/__init__.py
+++ b/src/llama_stack/providers/remote/inference/bedrock/__init__.py
@@ -3,10 +3,19 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from llama_stack_api import Api
+
 from .config import BedrockConfig
 
+if TYPE_CHECKING:
+    from .bedrock import BedrockInferenceAdapter
 
-async def get_adapter_impl(config: BedrockConfig, _deps):
+
+async def get_adapter_impl(config: BedrockConfig, _deps: dict[Api, Any]) -> BedrockInferenceAdapter:
     from .bedrock import BedrockInferenceAdapter
 
     assert isinstance(config, BedrockConfig), f"Unexpected config type: {type(config)}"

--- a/src/llama_stack/providers/remote/inference/bedrock/config.py
+++ b/src/llama_stack/providers/remote/inference/bedrock/config.py
@@ -5,6 +5,7 @@
 # the root directory of this source tree.
 
 import os
+from typing import Any
 
 from pydantic import BaseModel, Field, SecretStr
 
@@ -29,7 +30,7 @@ class BedrockConfig(RemoteInferenceProviderConfig):
     )
 
     @classmethod
-    def sample_run_config(cls, **kwargs):
+    def sample_run_config(cls, **kwargs: Any) -> dict[str, Any]:
         return {
             "api_key": "${env.AWS_BEARER_TOKEN_BEDROCK:=}",
             "region_name": "${env.AWS_DEFAULT_REGION:=us-east-2}",

--- a/src/llama_stack/providers/remote/inference/nvidia/__init__.py
+++ b/src/llama_stack/providers/remote/inference/nvidia/__init__.py
@@ -3,13 +3,19 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
+from __future__ import annotations
 
-from llama_stack_api import Inference
+from typing import TYPE_CHECKING, Any
+
+from llama_stack_api import Api
 
 from .config import NVIDIAConfig
 
+if TYPE_CHECKING:
+    from .nvidia import NVIDIAInferenceAdapter
 
-async def get_adapter_impl(config: NVIDIAConfig, _deps) -> Inference:
+
+async def get_adapter_impl(config: NVIDIAConfig, _deps: dict[Api, Any]) -> NVIDIAInferenceAdapter:
     # import dynamically so `llama stack list-deps` does not fail due to missing dependencies
     from .nvidia import NVIDIAInferenceAdapter
 

--- a/src/llama_stack/providers/remote/inference/nvidia/config.py
+++ b/src/llama_stack/providers/remote/inference/nvidia/config.py
@@ -46,7 +46,7 @@ class NVIDIAConfig(RemoteInferenceProviderConfig):
     URL of your running NVIDIA NIM and do not need to set the api_key.
     """
 
-    base_url: HttpUrl | None = Field(
+    base_url: HttpUrl | None = Field(  # ty: ignore[invalid-assignment]  # Pydantic Field
         default_factory=lambda: os.getenv("NVIDIA_BASE_URL", "https://integrate.api.nvidia.com/v1"),
         description="A base url for accessing the NVIDIA NIM",
     )
@@ -66,7 +66,7 @@ class NVIDIAConfig(RemoteInferenceProviderConfig):
     @classmethod
     def sample_run_config(
         cls,
-        base_url: HttpUrl | None = "${env.NVIDIA_BASE_URL:=https://integrate.api.nvidia.com/v1}",
+        base_url: HttpUrl | None = "${env.NVIDIA_BASE_URL:=https://integrate.api.nvidia.com/v1}",  # ty: ignore[invalid-parameter-default]  # resolved at runtime
         api_key: str = "${env.NVIDIA_API_KEY:=}",
         **kwargs,
     ) -> dict[str, Any]:

--- a/src/llama_stack/providers/remote/inference/nvidia/nvidia.py
+++ b/src/llama_stack/providers/remote/inference/nvidia/nvidia.py
@@ -54,7 +54,7 @@ class NVIDIAInferenceAdapter(OpenAIMixin):
                     "API key is required for hosted NVIDIA NIM. Either provide an API key or use a self-hosted NIM."
                 )
 
-    def get_api_key(self) -> str:
+    def get_api_key(self) -> str | None:
         """
         Get the API key for OpenAI mixin.
 
@@ -96,7 +96,7 @@ class NVIDIAInferenceAdapter(OpenAIMixin):
         """
         if identifier in self.config.rerank_model_to_url:
             return Model(
-                provider_id=self.__provider_id__,  # type: ignore[attr-defined]
+                provider_id=self.__provider_id__,  # ty: ignore[unresolved-attribute]  # injected at runtime
                 provider_resource_id=identifier,
                 identifier=identifier,
                 model_type=ModelType.rerank,

--- a/src/llama_stack/providers/remote/inference/oci/__init__.py
+++ b/src/llama_stack/providers/remote/inference/oci/__init__.py
@@ -3,13 +3,19 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
+from __future__ import annotations
 
-from llama_stack_api import InferenceProvider
+from typing import TYPE_CHECKING, Any
+
+from llama_stack_api import Api
 
 from .config import OCIConfig
 
+if TYPE_CHECKING:
+    from .oci import OCIInferenceAdapter
 
-async def get_adapter_impl(config: OCIConfig, _deps) -> InferenceProvider:
+
+async def get_adapter_impl(config: OCIConfig, _deps: dict[Api, Any]) -> OCIInferenceAdapter:
     from .oci import OCIInferenceAdapter
 
     adapter = OCIInferenceAdapter(config=config)

--- a/src/llama_stack/providers/remote/inference/oci/auth.py
+++ b/src/llama_stack/providers/remote/inference/oci/auth.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-from collections.abc import Generator, Mapping
+from collections.abc import Generator
 from typing import Any, override
 
 import httpx
@@ -48,7 +48,7 @@ class HttpxOciAuth(httpx.Auth):
         prepared_request = req.prepare()
 
         # Sign the request using the OCI Signer
-        self.signer.do_request_sign(prepared_request)  # type: ignore
+        self.signer.do_request_sign(prepared_request)  # ty: ignore[missing-argument]  # OCI SDK typing limitation
 
         # Update the original HTTPX request with the signed headers
         request.headers.update(prepared_request.headers)
@@ -59,7 +59,7 @@ class HttpxOciAuth(httpx.Auth):
 class OciInstancePrincipalAuth(HttpxOciAuth):
     """OCI authentication using instance principal credentials."""
 
-    def __init__(self, **kwargs: Mapping[str, Any]):
+    def __init__(self, **kwargs: Any):
         self.signer = oci.auth.signers.InstancePrincipalsSecurityTokenSigner(**kwargs)
 
 
@@ -68,7 +68,7 @@ class OciUserPrincipalAuth(HttpxOciAuth):
 
     def __init__(self, config_file: str = DEFAULT_LOCATION, profile_name: str = DEFAULT_PROFILE):
         config = oci.config.from_file(config_file, profile_name)
-        oci.config.validate_config(config)  # type: ignore
+        oci.config.validate_config(config)  # type: ignore[arg-type]
         key_content = ""
         with open(config["key_file"]) as f:
             key_content = f.read()
@@ -78,6 +78,6 @@ class OciUserPrincipalAuth(HttpxOciAuth):
             user=config["user"],
             fingerprint=config["fingerprint"],
             private_key_file_location=config.get("key_file"),
-            pass_phrase="none",  # type: ignore
+            pass_phrase="none",  # type: ignore[arg-type]
             private_key_content=key_content,
         )

--- a/src/llama_stack/providers/remote/inference/oci/oci.py
+++ b/src/llama_stack/providers/remote/inference/oci/oci.py
@@ -78,7 +78,7 @@ class OCIInferenceAdapter(OpenAIMixin):
             return oci.auth.signers.InstancePrincipalsSecurityTokenSigner()
         return None
 
-    def _get_oci_config(self) -> dict:
+    def _get_oci_config(self) -> dict[str, Any]:
         if self.config.oci_auth_type == OCI_AUTH_TYPE_INSTANCE_PRINCIPAL:
             config = {"region": self.config.oci_region}
         elif self.config.oci_auth_type == OCI_AUTH_TYPE_CONFIG_FILE:
@@ -152,13 +152,13 @@ class OCIInferenceAdapter(OpenAIMixin):
         """
         if identifier in self.embedding_models:
             return Model(
-                provider_id=self.__provider_id__,  # type: ignore[attr-defined]
+                provider_id=self.__provider_id__,  # ty: ignore[unresolved-attribute]  # injected at runtime
                 provider_resource_id=identifier,
                 identifier=identifier,
                 model_type=ModelType.embedding,
             )
         return Model(
-            provider_id=self.__provider_id__,  # type: ignore[attr-defined]
+            provider_id=self.__provider_id__,  # ty: ignore[unresolved-attribute]  # injected at runtime
             provider_resource_id=identifier,
             identifier=identifier,
             model_type=ModelType.llm,

--- a/src/llama_stack/providers/remote/inference/passthrough/__init__.py
+++ b/src/llama_stack/providers/remote/inference/passthrough/__init__.py
@@ -3,10 +3,18 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, ConfigDict, HttpUrl, SecretStr
 
+from llama_stack_api import Api
+
 from .config import PassthroughImplConfig
+
+if TYPE_CHECKING:
+    from .passthrough import PassthroughInferenceAdapter
 
 
 class PassthroughProviderDataValidator(BaseModel):
@@ -24,7 +32,7 @@ class PassthroughProviderDataValidator(BaseModel):
     passthrough_api_key: SecretStr | None = None
 
 
-async def get_adapter_impl(config: PassthroughImplConfig, _deps):
+async def get_adapter_impl(config: PassthroughImplConfig, _deps: dict[Api, Any]) -> PassthroughInferenceAdapter:
     from .passthrough import PassthroughInferenceAdapter
 
     if not isinstance(config, PassthroughImplConfig):

--- a/src/llama_stack/providers/remote/inference/passthrough/config.py
+++ b/src/llama_stack/providers/remote/inference/passthrough/config.py
@@ -53,7 +53,7 @@ class PassthroughImplConfig(RemoteInferenceProviderConfig):
     @classmethod
     def sample_run_config(
         cls,
-        base_url: HttpUrl | None = "${env.PASSTHROUGH_URL}",
+        base_url: HttpUrl | None = "${env.PASSTHROUGH_URL}",  # ty: ignore[invalid-parameter-default]  # resolved at runtime
         api_key: str = "${env.PASSTHROUGH_API_KEY:=}",
         forward_headers: dict[str, str] | None = None,
         extra_blocked_headers: list[str] | None = None,

--- a/src/llama_stack/providers/remote/inference/passthrough/passthrough.py
+++ b/src/llama_stack/providers/remote/inference/passthrough/passthrough.py
@@ -60,11 +60,11 @@ class PassthroughInferenceAdapter(NeedsRequestProviderData, Inference):
             custom_metadata = getattr(model_data, "custom_metadata", {}) or {}
 
             # Prefix identifier with provider ID for local registry
-            local_identifier = f"{self.__provider_id__}/{downstream_model_id}"
+            local_identifier = f"{self.__provider_id__}/{downstream_model_id}"  # ty: ignore[unresolved-attribute]  # injected at runtime
 
             model = Model(
                 identifier=local_identifier,
-                provider_id=self.__provider_id__,
+                provider_id=self.__provider_id__,  # ty: ignore[unresolved-attribute]  # injected at runtime
                 provider_resource_id=downstream_model_id,
                 model_type=custom_metadata.get("model_type", "llm"),
                 metadata=custom_metadata,
@@ -156,7 +156,7 @@ class PassthroughInferenceAdapter(NeedsRequestProviderData, Inference):
         if params.stream:
             return wrap_async_stream(response)
 
-        return response  # type: ignore[return-value]
+        return response  # type: ignore[return-value][return-value]
 
     async def openai_chat_completion(
         self,
@@ -170,7 +170,7 @@ class PassthroughInferenceAdapter(NeedsRequestProviderData, Inference):
         if params.stream:
             return wrap_async_stream(response)
 
-        return response  # type: ignore[return-value]
+        return response  # type: ignore[return-value][return-value]
 
     async def openai_embeddings(
         self,
@@ -180,4 +180,4 @@ class PassthroughInferenceAdapter(NeedsRequestProviderData, Inference):
         client = self._get_openai_client()
         request_params = params.model_dump(exclude_none=True)
         response = await client.embeddings.create(**request_params)
-        return response  # type: ignore
+        return response  # type: ignore[return-value]  # ty: ignore[invalid-return-type]

--- a/src/llama_stack/providers/remote/inference/runpod/__init__.py
+++ b/src/llama_stack/providers/remote/inference/runpod/__init__.py
@@ -3,11 +3,19 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from llama_stack_api import Api
 
 from .config import RunpodImplConfig
 
+if TYPE_CHECKING:
+    from .runpod import RunpodInferenceAdapter
 
-async def get_adapter_impl(config: RunpodImplConfig, _deps):
+
+async def get_adapter_impl(config: RunpodImplConfig, _deps: dict[Api, Any]) -> RunpodInferenceAdapter:
     from .runpod import RunpodInferenceAdapter
 
     assert isinstance(config, RunpodImplConfig), f"Unexpected config type: {type(config)}"

--- a/src/llama_stack/providers/remote/inference/watsonx/__init__.py
+++ b/src/llama_stack/providers/remote/inference/watsonx/__init__.py
@@ -3,11 +3,19 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from llama_stack_api import Api
 
 from .config import WatsonXConfig
 
+if TYPE_CHECKING:
+    from .watsonx import WatsonXInferenceAdapter
 
-async def get_adapter_impl(config: WatsonXConfig, _deps):
+
+async def get_adapter_impl(config: WatsonXConfig, _deps: dict[Api, Any]) -> WatsonXInferenceAdapter:
     # import dynamically so the import is used only when it is needed
     from .watsonx import WatsonXInferenceAdapter
 

--- a/src/llama_stack/providers/remote/inference/watsonx/config.py
+++ b/src/llama_stack/providers/remote/inference/watsonx/config.py
@@ -27,7 +27,7 @@ class WatsonXProviderDataValidator(BaseModel):
 class WatsonXConfig(RemoteInferenceProviderConfig):
     """Configuration for the IBM WatsonX inference provider."""
 
-    base_url: HttpUrl | None = Field(
+    base_url: HttpUrl | None = Field(  # ty: ignore[invalid-assignment]  # Pydantic Field
         default_factory=lambda: os.getenv("WATSONX_BASE_URL", "https://us-south.ml.cloud.ibm.com"),
         description="A base url for accessing the watsonx.ai",
     )
@@ -41,7 +41,7 @@ class WatsonXConfig(RemoteInferenceProviderConfig):
     )
 
     @classmethod
-    def sample_run_config(cls, **kwargs) -> dict[str, Any]:
+    def sample_run_config(cls, **kwargs: Any) -> dict[str, Any]:
         return {
             "base_url": "${env.WATSONX_BASE_URL:=https://us-south.ml.cloud.ibm.com}",
             "api_key": "${env.WATSONX_API_KEY:=}",

--- a/src/llama_stack/providers/remote/inference/watsonx/watsonx.py
+++ b/src/llama_stack/providers/remote/inference/watsonx/watsonx.py
@@ -35,6 +35,8 @@ WATSONX_API_VERSION = "2023-10-25"
 class WatsonXInferenceAdapter(OpenAIMixin):
     """Inference adapter for IBM WatsonX AI platform."""
 
+    config: WatsonXConfig
+
     _model_cache: dict[str, Model] = {}
 
     provider_data_api_key_field: str = "watsonx_api_key"
@@ -42,7 +44,7 @@ class WatsonXInferenceAdapter(OpenAIMixin):
     # WatsonX does not support stream_options
     supports_stream_options: bool = False
 
-    def __init__(self, config: WatsonXConfig):
+    def __init__(self, config: WatsonXConfig) -> None:
         super().__init__(config=config)
         self._iam_token_cache: dict[str, tuple[str, float]] = {}
         self._model_specs_cache: list[dict[str, Any]] | None = None
@@ -163,7 +165,7 @@ class WatsonXInferenceAdapter(OpenAIMixin):
                 break
 
         return Model(
-            provider_id=self.__provider_id__,
+            provider_id=self.__provider_id__,  # ty: ignore[unresolved-attribute]  # injected at runtime
             provider_resource_id=identifier,
             identifier=identifier,
             model_type=model_type,


### PR DESCRIPTION
## Summary
- Add parameter and return type annotations to all `get_adapter_impl` functions across 6 remote inference providers (bedrock, nvidia, oci, passthrough, runpod, watsonx)
- Fix `get_api_key` return type in nvidia provider (`str` → `str | None`)
- Add `config: WatsonXConfig` class attribute declaration to `WatsonXInferenceAdapter`
- Add `ty: ignore` comments with proper error codes for runtime-injected `__provider_id__` attributes
- Add `ty: ignore` for Pydantic `Field` assignments and SDK typing limitations
- Fix bare `# type: ignore` comments to include error codes
- Remove unused `Mapping` import from `oci/auth.py`

## Verification
- `ty check` passes with zero errors on all 6 provider directories
- No behavioral changes — annotation-only modifications
- `uv run pytest tests/unit/` blocked by network (PyPI unreachable in this env)

Closes #75

## Test plan
- [x] `ty check` passes on all in-scope directories
- [ ] `uv run pytest tests/unit/ -x` (blocked by network — needs CI verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)