### PR TITLE
Add type annotations to core server lifecycle

### DIFF
--- a/src/llama_stack/core/admin.py
+++ b/src/llama_stack/core/admin.py
@@ -44,7 +44,7 @@ class AdminImplConfig(BaseModel):
     config: StackConfig
 
 
-async def get_provider_impl(config, deps):
+async def get_provider_impl(config: AdminImplConfig, deps: dict[Api, Any]) -> "AdminImpl":
     """Create and initialize an AdminImpl instance.
 
     Args:
@@ -62,7 +62,7 @@ async def get_provider_impl(config, deps):
 class AdminImpl(Admin):
     """Implementation of the Admin API providing provider management, route listing, health, and version endpoints."""
 
-    def __init__(self, config: AdminImplConfig, deps):
+    def __init__(self, config: AdminImplConfig, deps: dict[Api, Any]) -> None:
         self.config = config
         self.deps = deps
 

--- a/src/llama_stack/core/client.py
+++ b/src/llama_stack/core/client.py
@@ -20,7 +20,7 @@ from llama_stack_api import RemoteProviderConfig
 _CLIENT_CLASSES = {}
 
 
-async def get_client_impl(protocol, config: RemoteProviderConfig, _deps: Any):
+async def get_client_impl(protocol: type, config: RemoteProviderConfig, _deps: Any) -> Any:
     """Create and initialize an API client for a remote provider.
 
     Args:
@@ -37,7 +37,7 @@ async def get_client_impl(protocol, config: RemoteProviderConfig, _deps: Any):
     return impl
 
 
-def create_api_client_class(protocol) -> type:
+def create_api_client_class(protocol: type) -> type:
     """Dynamically create an API client class for the given protocol.
 
     Args:
@@ -92,7 +92,7 @@ def create_api_client_class(protocol) -> type:
                 response.raise_for_status()
 
                 j = response.json()
-                if j is None:
+                if j is None or return_type is None:
                     return None
                 # print(f"({protocol.__name__}) Returning {j}, type {return_type}")
                 return parse_obj_as(return_type, j)
@@ -194,7 +194,7 @@ def create_api_client_class(protocol) -> type:
 
             method_impl.__name__ = name
             method_impl.__qualname__ = f"APIClient.{name}"
-            method_impl.__signature__ = inspect.signature(method)
+            method_impl.__signature__ = inspect.signature(method)  # ty: ignore[unresolved-attribute]
             setattr(APIClient, name, method_impl)
 
     # Name the class after the protocol
@@ -203,7 +203,7 @@ def create_api_client_class(protocol) -> type:
     return APIClient
 
 
-def extract_non_async_iterator_type(type_hint):
+def extract_non_async_iterator_type(type_hint: Any) -> Any:
     """Extract the non-AsyncIterator type from a Union type hint.
 
     Args:
@@ -220,7 +220,7 @@ def extract_non_async_iterator_type(type_hint):
     return type_hint
 
 
-def extract_async_iterator_type(type_hint):
+def extract_async_iterator_type(type_hint: Any) -> Any:
     """Extract the inner type from an AsyncIterator within a Union type hint.
 
     Args:

--- a/src/llama_stack/core/inspect.py
+++ b/src/llama_stack/core/inspect.py
@@ -5,6 +5,7 @@
 # the root directory of this source tree.
 
 from importlib.metadata import version
+from typing import Any
 
 from pydantic import BaseModel
 
@@ -34,7 +35,7 @@ class DistributionInspectConfig(BaseModel):
     config: StackConfig
 
 
-async def get_provider_impl(config, deps):
+async def get_provider_impl(config: DistributionInspectConfig, deps: dict[Api, Any]) -> "DistributionInspectImpl":
     """Create and initialize a DistributionInspectImpl instance.
 
     Args:
@@ -52,7 +53,7 @@ async def get_provider_impl(config, deps):
 class DistributionInspectImpl(Inspect):
     """Implementation of the Inspect API providing route listing, health, and version endpoints."""
 
-    def __init__(self, config: DistributionInspectConfig, deps):
+    def __init__(self, config: DistributionInspectConfig, deps: dict[Api, Any]) -> None:
         self.stack_config = config.config
         self.deps = deps
 

--- a/src/llama_stack/core/providers.py
+++ b/src/llama_stack/core/providers.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 
 from llama_stack.log import get_logger
 from llama_stack_api import (
+    Api,
     HealthResponse,
     HealthStatus,
     InspectProviderRequest,
@@ -31,7 +32,7 @@ class ProviderImplConfig(BaseModel):
     config: StackConfig
 
 
-async def get_provider_impl(config, deps):
+async def get_provider_impl(config: ProviderImplConfig, deps: dict[Api, Any]) -> "ProviderImpl":
     """Create and initialize a ProviderImpl instance.
 
     Args:
@@ -49,7 +50,7 @@ async def get_provider_impl(config, deps):
 class ProviderImpl(Providers):
     """Implementation of the Providers API for listing and inspecting configured providers."""
 
-    def __init__(self, config, deps):
+    def __init__(self, config: ProviderImplConfig, deps: dict[Api, Any]) -> None:
         self.stack_config = config.config
         self.deps = deps
 

--- a/src/llama_stack/core/stack.py
+++ b/src/llama_stack/core/stack.py
@@ -11,7 +11,7 @@ import os
 import re
 import tempfile
 from pathlib import Path
-from typing import Any, get_type_hints
+from typing import Any, cast, get_type_hints
 
 import yaml
 from pydantic import BaseModel
@@ -520,12 +520,13 @@ def replace_env_vars(config: Any, path: str = "") -> Any:
                 # Special handling for providers: first resolve the provider_id to check if provider
                 # is disabled so that we can skip config env variable expansion and avoid validation errors
                 if isinstance(v, dict) and "provider_id" in v:
+                    v_dict = cast(dict[str, Any], v)
                     try:
-                        resolved_provider_id = replace_env_vars(v["provider_id"], f"{path}[{i}].provider_id")
+                        resolved_provider_id = replace_env_vars(v_dict["provider_id"], f"{path}[{i}].provider_id")
                         if resolved_provider_id == "__disabled__":
                             logger.debug(
                                 "Skipping config env variable expansion for disabled provider",
-                                v_get_provider_id=v.get("provider_id", ""),
+                                v_get_provider_id=v_dict.get("provider_id", ""),
                             )
                             continue
                     except EnvVarError:
@@ -535,11 +536,12 @@ def replace_env_vars(config: Any, path: str = "") -> Any:
                 # Special handling for registered resources: check if ID field resolves to empty/None
                 # from conditional env vars (e.g., ${env.VAR:+value}) and skip the entry if so
                 if isinstance(v, dict):
+                    v_res = cast(dict[str, Any], v)
                     should_skip = False
                     for id_field in RESOURCE_ID_FIELDS:
-                        if id_field in v:
+                        if id_field in v_res:
                             try:
-                                resolved_id = replace_env_vars(v[id_field], f"{path}[{i}].{id_field}")
+                                resolved_id = replace_env_vars(v_res[id_field], f"{path}[{i}].{id_field}")
                                 if resolved_id is None or resolved_id == "":
                                     logger.debug(
                                         "Skipping [] with empty (conditional env var not set)",
@@ -741,7 +743,7 @@ class Stack:
         stores = self.run_config.storage.stores
         if not stores.metadata:
             raise ValueError("storage.stores.metadata must be configured with a kv_* backend")
-        dist_registry, _ = await create_dist_registry(stores.metadata, self.run_config.distro_name)
+        dist_registry, _ = await create_dist_registry(stores.metadata, self.run_config.distro_name or "")
         policy = self.run_config.server.auth.access_policy if self.run_config.server.auth else []
 
         internal_impls = {}
@@ -789,7 +791,9 @@ class Stack:
 
         REGISTRY_REFRESH_TASK.add_done_callback(cb)
 
-    async def shutdown(self):
+    async def shutdown(self) -> None:
+        if self.impls is None:
+            return
         for impl in self.impls.values():
             impl_name = impl.__class__.__name__
             logger.debug("Shutting down", impl_name=impl_name)
@@ -922,7 +926,8 @@ def run_config_from_dynamic_config_spec(
 
         # call method "sample_run_config" on the provider spec config class
         provider_config_type = instantiate_class_type(provider_spec.config_class)
-        provider_config = replace_env_vars(provider_config_type.sample_run_config(__distro_dir__=str(distro_dir)))
+        sample_run_config_fn = getattr(provider_config_type, "sample_run_config")
+        provider_config = replace_env_vars(sample_run_config_fn(__distro_dir__=str(distro_dir)))
 
         # Apply config overrides
         provider_config.update(config_overrides)

--- a/src/llama_stack/core/testing_context.py
+++ b/src/llama_stack/core/testing_context.py
@@ -5,7 +5,7 @@
 # the root directory of this source tree.
 
 import os
-from contextvars import ContextVar
+from contextvars import ContextVar, Token
 
 from llama_stack.core.request_headers import PROVIDER_DATA_VAR
 
@@ -21,7 +21,7 @@ def get_test_context() -> str | None:
     return TEST_CONTEXT.get()
 
 
-def set_test_context(value: str | None):
+def set_test_context(value: str | None) -> Token[str | None]:
     """Set the test context identifier for the current async context.
 
     Args:
@@ -33,7 +33,7 @@ def set_test_context(value: str | None):
     return TEST_CONTEXT.set(value)
 
 
-def reset_test_context(token) -> None:
+def reset_test_context(token: Token[str | None]) -> None:
     """Reset the test context to its previous value using a token from set_test_context.
 
     Args:
@@ -42,7 +42,7 @@ def reset_test_context(token) -> None:
     TEST_CONTEXT.reset(token)
 
 
-def sync_test_context_from_provider_data():
+def sync_test_context_from_provider_data() -> Token[str | None] | None:
     """Sync test context from provider data when running in server test mode."""
     if "LLAMA_STACK_TEST_INFERENCE_MODE" not in os.environ:
         return None

--- a/src/llama_stack/core/utils/context.py
+++ b/src/llama_stack/core/utils/context.py
@@ -5,7 +5,8 @@
 # the root directory of this source tree.
 
 from collections.abc import AsyncGenerator
-from contextvars import ContextVar
+from contextvars import ContextVar, Token
+from typing import Any
 
 _MISSING = object()
 
@@ -23,8 +24,8 @@ def preserve_contexts_async_generator[T](
 
     async def wrapper() -> AsyncGenerator[T, None]:
         while True:
-            previous_values: dict[ContextVar, object] = {}
-            tokens: dict[ContextVar, object] = {}
+            previous_values: dict[ContextVar[Any], Any] = {}
+            tokens: dict[ContextVar[Any], Token[Any]] = {}
 
             # Restore ALL context values before any await and capture previous state
             # This is needed to propagate context across async generator boundaries
@@ -35,7 +36,7 @@ def preserve_contexts_async_generator[T](
                     previous_values[context_var] = _MISSING
                 tokens[context_var] = context_var.set(initial_context_values[context_var.name])
 
-            def _restore_context_var(context_var: ContextVar, *, _tokens=tokens, _prev=previous_values) -> None:
+            def _restore_context_var(context_var: ContextVar[Any], *, _tokens: dict[ContextVar[Any], Token[Any]] = tokens, _prev: dict[ContextVar[Any], Any] = previous_values) -> None:
                 token = _tokens.get(context_var)
                 previous_value = _prev.get(context_var, _MISSING)
                 if token is not None:

--- a/src/llama_stack/core/utils/dynamic.py
+++ b/src/llama_stack/core/utils/dynamic.py
@@ -7,7 +7,7 @@
 import importlib
 
 
-def instantiate_class_type(fully_qualified_name):
+def instantiate_class_type(fully_qualified_name: str) -> type:
     """Import and return a class from its fully qualified module path.
 
     Args:

--- a/src/llama_stack/core/utils/exec.py
+++ b/src/llama_stack/core/utils/exec.py
@@ -5,6 +5,7 @@
 # the root directory of this source tree.
 
 import importlib
+import importlib.resources
 import os
 import signal
 import subprocess

--- a/src/llama_stack/core/utils/prompt_for_config.py
+++ b/src/llama_stack/core/utils/prompt_for_config.py
@@ -18,7 +18,7 @@ from llama_stack.log import get_logger
 log = get_logger(name=__name__, category="core")
 
 
-def is_list_of_primitives(field_type):
+def is_list_of_primitives(field_type: Any) -> bool:
     """Check if a field type is a List of primitive types."""
     origin = get_origin(field_type)
     if origin is list or origin is list:
@@ -28,7 +28,7 @@ def is_list_of_primitives(field_type):
     return False
 
 
-def is_basemodel_without_fields(typ):
+def is_basemodel_without_fields(typ: Any) -> bool:
     """Check if a type is a Pydantic BaseModel subclass with no defined fields.
 
     Args:
@@ -40,7 +40,7 @@ def is_basemodel_without_fields(typ):
     return inspect.isclass(typ) and issubclass(typ, BaseModel) and len(typ.__fields__) == 0
 
 
-def can_recurse(typ):
+def can_recurse(typ: Any) -> bool:
     """Check if a type is a Pydantic BaseModel subclass with fields that can be recursively prompted.
 
     Args:
@@ -52,24 +52,24 @@ def can_recurse(typ):
     return inspect.isclass(typ) and issubclass(typ, BaseModel) and len(typ.__fields__) > 0
 
 
-def get_literal_values(field):
+def get_literal_values(field: FieldInfo) -> tuple[Any, ...] | None:
     """Extract literal values from a field if it's a Literal type."""
     if get_origin(field.annotation) is Literal:
         return get_args(field.annotation)
     return None
 
 
-def is_optional(field_type):
+def is_optional(field_type: Any) -> bool:
     """Check if a field type is Optional."""
     return get_origin(field_type) is Union and type(None) in get_args(field_type)
 
 
-def get_non_none_type(field_type):
+def get_non_none_type(field_type: Any) -> Any:
     """Get the non-None type from an Optional type."""
     return next(arg for arg in get_args(field_type) if arg is not type(None))
 
 
-def manually_validate_field(model: type[BaseModel], field_name: str, value: Any):
+def manually_validate_field(model: type[BaseModel], field_name: str, value: Any) -> Any:
     """Run Pydantic field validators manually on a single field value.
 
     Args:
@@ -88,7 +88,7 @@ def manually_validate_field(model: type[BaseModel], field_name: str, value: Any)
     return value
 
 
-def is_discriminated_union(typ) -> bool:
+def is_discriminated_union(typ: Any) -> bool:
     """Check if a type or FieldInfo represents a discriminated union.
 
     Args:
@@ -107,10 +107,10 @@ def is_discriminated_union(typ) -> bool:
 
 
 def prompt_for_discriminated_union(
-    field_name,
-    typ,
-    existing_value,
-):
+    field_name: str,
+    typ: Any,
+    existing_value: Any,
+) -> BaseModel:
     """Interactively prompt the user to select and configure a discriminated union variant.
 
     Args:
@@ -196,6 +196,9 @@ def prompt_for_config(config_type: type[BaseModel], existing_config: BaseModel |
             continue
 
         # Skip fields with no type annotations
+        if field_type is None:
+            continue
+
         if is_basemodel_without_fields(field_type):
             config_data[field_name] = field_type()
             continue
@@ -207,7 +210,7 @@ def prompt_for_config(config_type: type[BaseModel], existing_config: BaseModel |
                 user_input = input(prompt + " ")
                 try:
                     value = field_type[user_input]
-                    validated_value = manually_validate_field(config_type, field, value)
+                    validated_value = manually_validate_field(config_type, field_name, value)
                     config_data[field_name] = validated_value
                     break
                 except KeyError:
@@ -239,6 +242,7 @@ def prompt_for_config(config_type: type[BaseModel], existing_config: BaseModel |
             )
         elif can_recurse(field_type):
             log.info(f"\nEntering sub-configuration for {field_name}:")
+            assert field_type is not None  # guaranteed by can_recurse
             config_data[field_name] = prompt_for_config(
                 field_type,
                 existing_value,
@@ -309,8 +313,10 @@ def prompt_for_config(config_type: type[BaseModel], existing_config: BaseModel |
                             import ast
 
                             value = field_type(**ast.literal_eval(user_input))
-                        else:
+                        elif field_type is not None:
                             value = field_type(user_input)
+                        else:
+                            value = user_input
 
                     except ValueError:
                         log.error(f"Invalid input. Expected type: {getattr(field_type, '__name__', str(field_type))}")

--- a/src/llama_stack/core/utils/serialize.py
+++ b/src/llama_stack/core/utils/serialize.py
@@ -7,14 +7,15 @@
 import json
 from datetime import datetime
 from enum import Enum
+from typing import Any
 
 
 class EnumEncoder(json.JSONEncoder):
     """JSON encoder that serializes Enum values and datetime objects."""
 
-    def default(self, obj):
-        if isinstance(obj, Enum):
-            return obj.value
-        elif isinstance(obj, datetime):
-            return obj.isoformat()
-        return super().default(obj)
+    def default(self, o: Any) -> Any:
+        if isinstance(o, Enum):
+            return o.value
+        elif isinstance(o, datetime):
+            return o.isoformat()
+        return super().default(o)

--- a/src/llama_stack/telemetry/__init__.py
+++ b/src/llama_stack/telemetry/__init__.py
@@ -17,7 +17,7 @@ from llama_stack.log import get_logger
 logger = get_logger(__name__, category="telemetry")
 
 
-def setup_telemetry():
+def setup_telemetry() -> None:
     """Initialize OpenTelemetry metrics exporter if configured via environment.
 
     This function checks for OTEL_EXPORTER_OTLP_ENDPOINT and configures the


### PR DESCRIPTION
## Summary
- Add proper type annotations to 14 core server lifecycle files so they pass `ty check` with zero errors
- Fix a bug in `prompt_for_config.py` where `FieldInfo` was passed instead of `str` to `manually_validate_field`
- Fix method override signature in `serialize.py` to match `JSONEncoder.default` parameter name

## Changes
- **admin.py, inspect.py, providers.py**: Add parameter + return types to `get_provider_impl()` and `__init__`
- **client.py**: Type `get_client_impl`, `create_api_client_class`, extract functions
- **dynamic.py**: Type `instantiate_class_type`
- **prompt_for_config.py**: Type all helper functions, fix bug passing FieldInfo instead of field_name str, add None guard for `field.annotation`
- **serialize.py**: Fix `default` method parameter name to match `JSONEncoder.default(self, o)` signature, add `Any` type
- **context.py**: Use proper `Token[Any]` types instead of `object`
- **testing_context.py**: Add `Token` return types, type `sync_test_context_from_provider_data`
- **telemetry/__init__.py**: Add `-> None` return type to `setup_telemetry`
- **exec.py**: Add explicit `importlib.resources` import
- **stack.py**: Fix None-safe `shutdown`, use `cast` for dict narrowing, add `or ""` fallback for distro_name, use `getattr` for dynamic `sample_run_config`

## Verification
- `ty check` on all 14 files: **0 errors** (3 pre-existing deprecation warnings for `parse_obj_as`)
- `pytest tests/unit/core/ tests/unit/distribution/ tests/unit/providers/inference/`: **629 passed**

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)