### PR TITLE
Add type annotations to shared inference utilities and bedrock utils

### DIFF
--- a/src/llama_stack/providers/utils/bedrock/client.py
+++ b/src/llama_stack/providers/utils/bedrock/client.py
@@ -5,9 +5,9 @@
 # the root directory of this source tree.
 
 
-import boto3
-from botocore.client import BaseClient
-from botocore.config import Config
+import boto3  # type: ignore[import-untyped]  # ty: ignore[unresolved-import]
+from botocore.client import BaseClient  # type: ignore[import-untyped]  # ty: ignore[unresolved-import]
+from botocore.config import Config  # type: ignore[import-untyped]  # ty: ignore[unresolved-import]
 
 from llama_stack.providers.utils.bedrock.config import BedrockBaseConfig
 from llama_stack.providers.utils.bedrock.refreshable_boto_session import (
@@ -63,11 +63,12 @@ def create_bedrock_client(config: BedrockBaseConfig, service_name: str = "bedroc
         boto3_session = boto3.session.Session(**session_args)
         return boto3_session.client(service_name, config=boto3_config)
     else:
+        session_ttl = config.session_ttl if config.session_ttl is not None else 30000
         return (
             RefreshableBotoSession(
                 region_name=config.region_name,
                 profile_name=config.profile_name,
-                session_ttl=config.session_ttl,
+                session_ttl=session_ttl,
             )
             .refreshable_session()
             .client(service_name)

--- a/src/llama_stack/providers/utils/bedrock/client.py
+++ b/src/llama_stack/providers/utils/bedrock/client.py
@@ -5,9 +5,9 @@
 # the root directory of this source tree.
 
 
-import boto3
-from botocore.client import BaseClient
-from botocore.config import Config
+import boto3  # ty: ignore[unresolved-import]
+from botocore.client import BaseClient  # ty: ignore[unresolved-import]
+from botocore.config import Config  # ty: ignore[unresolved-import]
 
 from llama_stack.providers.utils.bedrock.config import BedrockBaseConfig
 from llama_stack.providers.utils.bedrock.refreshable_boto_session import (

--- a/src/llama_stack/providers/utils/bedrock/config.py
+++ b/src/llama_stack/providers/utils/bedrock/config.py
@@ -5,6 +5,7 @@
 # the root directory of this source tree.
 
 import os
+from typing import Any
 
 from pydantic import Field, SecretStr
 
@@ -62,5 +63,5 @@ class BedrockBaseConfig(RemoteInferenceProviderConfig):
     )
 
     @classmethod
-    def sample_run_config(cls, **kwargs):
+    def sample_run_config(cls, **kwargs: Any) -> dict[str, Any]:
         return {}

--- a/src/llama_stack/providers/utils/bedrock/refreshable_boto_session.py
+++ b/src/llama_stack/providers/utils/bedrock/refreshable_boto_session.py
@@ -8,9 +8,9 @@ import datetime
 from time import time
 from uuid import uuid4
 
-from boto3 import Session
-from botocore.credentials import RefreshableCredentials
-from botocore.session import get_session
+from boto3 import Session  # ty: ignore[unresolved-import]
+from botocore.credentials import RefreshableCredentials  # ty: ignore[unresolved-import]
+from botocore.session import get_session  # ty: ignore[unresolved-import]
 
 
 class RefreshableBotoSession:
@@ -26,11 +26,11 @@ class RefreshableBotoSession:
 
     def __init__(
         self,
-        region_name: str = None,
-        profile_name: str = None,
-        sts_arn: str = None,
-        session_name: str = None,
-        session_ttl: int = 30000,
+        region_name: str | None = None,
+        profile_name: str | None = None,
+        sts_arn: str | None = None,
+        session_name: str | None = None,
+        session_ttl: int | None = 30000,
     ):
         """
         Initialize `RefreshableBotoSession`
@@ -58,7 +58,7 @@ class RefreshableBotoSession:
         self.profile_name = profile_name
         self.sts_arn = sts_arn
         self.session_name = session_name or uuid4().hex
-        self.session_ttl = session_ttl
+        self.session_ttl: int = session_ttl if session_ttl is not None else 30000
 
     def __get_session_credentials(self):
         """

--- a/src/llama_stack/providers/utils/bedrock/refreshable_boto_session.py
+++ b/src/llama_stack/providers/utils/bedrock/refreshable_boto_session.py
@@ -8,9 +8,9 @@ import datetime
 from time import time
 from uuid import uuid4
 
-from boto3 import Session
-from botocore.credentials import RefreshableCredentials
-from botocore.session import get_session
+from boto3 import Session  # type: ignore[import-untyped]  # ty: ignore[unresolved-import]
+from botocore.credentials import RefreshableCredentials  # type: ignore[import-untyped]  # ty: ignore[unresolved-import]
+from botocore.session import get_session  # type: ignore[import-untyped]  # ty: ignore[unresolved-import]
 
 
 class RefreshableBotoSession:
@@ -26,10 +26,10 @@ class RefreshableBotoSession:
 
     def __init__(
         self,
-        region_name: str = None,
-        profile_name: str = None,
-        sts_arn: str = None,
-        session_name: str = None,
+        region_name: str | None = None,
+        profile_name: str | None = None,
+        sts_arn: str | None = None,
+        session_name: str | None = None,
         session_ttl: int = 30000,
     ):
         """
@@ -60,7 +60,7 @@ class RefreshableBotoSession:
         self.session_name = session_name or uuid4().hex
         self.session_ttl = session_ttl
 
-    def __get_session_credentials(self):
+    def __get_session_credentials(self) -> dict[str, str | None]:
         """
         Get session credentials
         """

--- a/src/llama_stack/providers/utils/common/data_schema_validator.py
+++ b/src/llama_stack/providers/utils/common/data_schema_validator.py
@@ -73,7 +73,7 @@ VALID_SCHEMAS_FOR_EVAL = [
 ]
 
 
-def get_valid_schemas(api_str: str):
+def get_valid_schemas(api_str: str) -> list[dict[str, Any]]:
     """Return the valid dataset schemas for the given API.
 
     Args:
@@ -93,7 +93,7 @@ def get_valid_schemas(api_str: str):
 def validate_dataset_schema(
     dataset_schema: dict[str, Any],
     expected_schemas: list[dict[str, Any]],
-):
+) -> None:
     """Validate that a dataset schema matches one of the expected schemas.
 
     Args:
@@ -107,7 +107,7 @@ def validate_dataset_schema(
 def validate_row_schema(
     input_row: dict[str, Any],
     expected_schemas: list[dict[str, Any]],
-):
+) -> None:
     """Validate that an input row contains keys from at least one expected schema.
 
     Args:

--- a/src/llama_stack/providers/utils/common/data_url.py
+++ b/src/llama_stack/providers/utils/common/data_url.py
@@ -7,7 +7,7 @@
 import re
 
 
-def parse_data_url(data_url: str):
+def parse_data_url(data_url: str) -> dict[str, str | bool | None]:
     """Parse a data URL into its component parts.
 
     Args:

--- a/src/llama_stack/providers/utils/inference/embedding_mixin.py
+++ b/src/llama_stack/providers/utils/inference/embedding_mixin.py
@@ -8,12 +8,12 @@ import asyncio
 import base64
 import platform
 import struct
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from llama_stack.log import get_logger
 
 if TYPE_CHECKING:
-    from sentence_transformers import SentenceTransformer
+    from sentence_transformers import SentenceTransformer  # ty: ignore[unresolved-import]
 
 from llama_stack_api import (
     ModelStore,
@@ -37,6 +37,7 @@ class SentenceTransformerEmbeddingMixin:
     """Mixin providing OpenAI-compatible embeddings via sentence-transformers models."""
 
     model_store: ModelStore
+    config: Any
 
     async def openai_embeddings(
         self,
@@ -98,8 +99,8 @@ class SentenceTransformerEmbeddingMixin:
             log.info(f"Loading sentence transformer for {model}...")
 
             def _load_model():
-                import torch
-                from sentence_transformers import SentenceTransformer
+                import torch  # ty: ignore[unresolved-import]
+                from sentence_transformers import SentenceTransformer  # ty: ignore[unresolved-import]
 
                 platform_name = platform.system()
                 if platform_name == DARWIN:

--- a/src/llama_stack/providers/utils/inference/embedding_mixin.py
+++ b/src/llama_stack/providers/utils/inference/embedding_mixin.py
@@ -8,12 +8,12 @@ import asyncio
 import base64
 import platform
 import struct
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from llama_stack.log import get_logger
 
 if TYPE_CHECKING:
-    from sentence_transformers import SentenceTransformer
+    from sentence_transformers import SentenceTransformer  # type: ignore[import-untyped]  # ty: ignore[unresolved-import]
 
 from llama_stack_api import (
     ModelStore,
@@ -37,6 +37,7 @@ class SentenceTransformerEmbeddingMixin:
     """Mixin providing OpenAI-compatible embeddings via sentence-transformers models."""
 
     model_store: ModelStore
+    config: Any  # provided by the concrete provider class
 
     async def openai_embeddings(
         self,
@@ -98,8 +99,8 @@ class SentenceTransformerEmbeddingMixin:
             log.info(f"Loading sentence transformer for {model}...")
 
             def _load_model():
-                import torch
-                from sentence_transformers import SentenceTransformer
+                import torch  # type: ignore[import-untyped]  # ty: ignore[unresolved-import]
+                from sentence_transformers import SentenceTransformer  # type: ignore[import-untyped]  # ty: ignore[unresolved-import]
 
                 platform_name = platform.system()
                 if platform_name == DARWIN:

--- a/src/llama_stack/providers/utils/inference/model_registry.py
+++ b/src/llama_stack/providers/utils/inference/model_registry.py
@@ -269,14 +269,18 @@ class ModelRegistryHelper(ModelsProtocolPrivate):
     async def should_refresh_models(self) -> bool:
         return False
 
-    def get_provider_model_id(self, identifier: str) -> str | None:
+    def get_provider_model_id(self, identifier: str | None) -> str | None:
+        if identifier is None:
+            return None
         return self.alias_to_provider_id_map.get(identifier, None)
 
     # TODO: why keep a separate llama model mapping?
-    def get_llama_model(self, provider_model_id: str) -> str | None:
+    def get_llama_model(self, provider_model_id: str | None) -> str | None:
+        if provider_model_id is None:
+            return None
         return self.provider_id_to_llama_model_map.get(provider_model_id, None)
 
-    async def check_model_availability(self, model: str) -> bool:
+    async def check_model_availability(self, model: str | None) -> bool:
         """
         Check if a specific model is available from the provider (non-static check).
 
@@ -291,6 +295,8 @@ class ModelRegistryHelper(ModelsProtocolPrivate):
         :param model: The model identifier to check.
         :return: True if the model is available dynamically, False otherwise.
         """
+        if model is None:
+            return False
         logger.info(
             "check_model_availability is not implemented for . Returning False by default.",
             __name__=self.__class__.__name__,
@@ -309,7 +315,7 @@ class ModelRegistryHelper(ModelsProtocolPrivate):
                 # note: we cannot provide a complete list of supported models without
                 #       getting a complete list from the provider, so we return "..."
                 all_supported_models = [*self.alias_to_provider_id_map.keys(), "..."]
-                raise UnsupportedModelError(model.provider_resource_id, all_supported_models)
+                raise UnsupportedModelError(model.provider_resource_id or "", all_supported_models)
 
         provider_resource_id = self.get_provider_model_id(model.model_id)
         if model.model_type == ModelType.embedding:
@@ -333,7 +339,7 @@ class ModelRegistryHelper(ModelsProtocolPrivate):
                     if llama_model not in ALL_HUGGINGFACE_REPOS_TO_MODEL_DESCRIPTOR:
                         raise ValueError(
                             f"Invalid llama_model '{llama_model}' specified in metadata. "
-                            f"Must be one of: {', '.join(ALL_HUGGINGFACE_REPOS_TO_MODEL_DESCRIPTOR.keys())}"
+                            f"Must be one of: {', '.join(str(k) for k in ALL_HUGGINGFACE_REPOS_TO_MODEL_DESCRIPTOR.keys())}"
                         )
                     self.provider_id_to_llama_model_map[model.provider_resource_id] = (
                         ALL_HUGGINGFACE_REPOS_TO_MODEL_DESCRIPTOR[llama_model]

--- a/src/llama_stack/providers/utils/inference/model_registry.py
+++ b/src/llama_stack/providers/utils/inference/model_registry.py
@@ -298,6 +298,9 @@ class ModelRegistryHelper(ModelsProtocolPrivate):
         return False
 
     async def register_model(self, model: Model) -> Model:
+        if model.provider_resource_id is None:
+            raise ValueError(f"Model {model.model_id} has no provider_resource_id")
+
         # Check if model is supported in static configuration
         supported_model_id = self.get_provider_model_id(model.provider_resource_id)
 
@@ -333,7 +336,7 @@ class ModelRegistryHelper(ModelsProtocolPrivate):
                     if llama_model not in ALL_HUGGINGFACE_REPOS_TO_MODEL_DESCRIPTOR:
                         raise ValueError(
                             f"Invalid llama_model '{llama_model}' specified in metadata. "
-                            f"Must be one of: {', '.join(ALL_HUGGINGFACE_REPOS_TO_MODEL_DESCRIPTOR.keys())}"
+                            f"Must be one of: {', '.join([str(k) for k in ALL_HUGGINGFACE_REPOS_TO_MODEL_DESCRIPTOR])}"
                         )
                     self.provider_id_to_llama_model_map[model.provider_resource_id] = (
                         ALL_HUGGINGFACE_REPOS_TO_MODEL_DESCRIPTOR[llama_model]

--- a/src/llama_stack/providers/utils/inference/openai_compat.py
+++ b/src/llama_stack/providers/utils/inference/openai_compat.py
@@ -57,7 +57,7 @@ def convert_tooldef_to_openai_tool(
     return out
 
 
-async def prepare_openai_completion_params(**params):
+async def prepare_openai_completion_params(**params: Any) -> dict[str, Any]:
     """Prepare keyword arguments for OpenAI-compatible completion calls.
 
     Args:

--- a/src/llama_stack/providers/utils/inference/openai_mixin.py
+++ b/src/llama_stack/providers/utils/inference/openai_mixin.py
@@ -32,6 +32,7 @@ from llama_stack_api import (
     ModelType,
     OpenAIChatCompletion,
     OpenAIChatCompletionChunk,
+    OpenAIChatCompletionContentPartImageParam,
     OpenAIChatCompletionRequestWithExtraBody,
     OpenAICompletion,
     OpenAICompletionRequestWithExtraBody,
@@ -73,6 +74,12 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
     # Allow extra fields so the routing infra can inject model_store, __provider_id__, etc.
     # Allow arbitrary types for shared_ssl_context
     model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
+
+    # Runtime-injected by the routing table (routing_tables/common.py).
+    # Cannot import the concrete type without circular dependency, so we use Any.
+    model_store: Any = None
+    # Runtime-injected provider identifier string
+    __provider_id__: str = ""
 
     config: RemoteInferenceProviderConfig
 
@@ -158,14 +165,14 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
         """
         if metadata := self.embedding_model_metadata.get(identifier):
             return Model(
-                provider_id=self.__provider_id__,  # type: ignore[attr-defined]
+                provider_id=self.__provider_id__,
                 provider_resource_id=identifier,
                 identifier=identifier,
                 model_type=ModelType.embedding,
                 metadata=metadata,
             )
         return Model(
-            provider_id=self.__provider_id__,  # type: ignore[attr-defined]
+            provider_id=self.__provider_id__,
             provider_resource_id=identifier,
             identifier=identifier,
             model_type=ModelType.llm,
@@ -290,11 +297,11 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
         :return: The provider-specific model ID (e.g., "gpt-4")
         """
         # self.model_store is injected by the distribution system at runtime
-        if not await self.model_store.has_model(model):  # type: ignore[attr-defined]
+        if not await self.model_store.has_model(model):
             return model
 
         # Look up the registered model to get the provider-specific model ID
-        model_obj: Model = await self.model_store.get_model(model)  # type: ignore[attr-defined]
+        model_obj: Model = await self.model_store.get_model(model)
         # provider_resource_id is str | None, but we expect it to be str for OpenAI calls
         if model_obj.provider_resource_id is None:
             raise ValueError(f"Model {model} has no provider_resource_id")
@@ -355,7 +362,7 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
             completion_kwargs["extra_body"] = extra_body
         resp = await self.client.completions.create(**completion_kwargs)
 
-        return await self._maybe_overwrite_id(resp, params.stream)  # type: ignore[no-any-return]
+        return await self._maybe_overwrite_id(resp, params.stream)
 
     async def openai_chat_completion(
         self,
@@ -379,7 +386,7 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
             async def _localize_image_url(m: OpenAIMessageParam) -> OpenAIMessageParam:
                 if isinstance(m.content, list):
                     for c in m.content:
-                        if c.type == "image_url" and c.image_url and c.image_url.url and "http" in c.image_url.url:
+                        if isinstance(c, OpenAIChatCompletionContentPartImageParam) and c.image_url and c.image_url.url and "http" in c.image_url.url:
                             localize_result = await localize_image_content(c.image_url.url)
                             if localize_result is None:
                                 raise ValueError(
@@ -426,7 +433,7 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
             request_params["extra_body"] = extra_body
         resp = await self.client.chat.completions.create(**request_params)
 
-        return await self._maybe_overwrite_id(resp, params.stream)  # type: ignore[no-any-return]
+        return await self._maybe_overwrite_id(resp, params.stream)
 
     async def openai_embeddings(
         self,
@@ -562,7 +569,7 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
         """
         # First check if the model is pre-registered in the model store
         if hasattr(self, "model_store") and self.model_store:
-            qualified_model = f"{self.__provider_id__}/{model}"  # type: ignore[attr-defined]
+            qualified_model = f"{self.__provider_id__}/{model}"
             if await self.model_store.has_model(qualified_model):
                 return True
 

--- a/src/llama_stack/providers/utils/inference/openai_mixin.py
+++ b/src/llama_stack/providers/utils/inference/openai_mixin.py
@@ -74,6 +74,11 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
     # Allow arbitrary types for shared_ssl_context
     model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
 
+    # Runtime-injected by routing_tables/common.py during provider initialization.
+    # Using Any to avoid circular imports with core/routing_tables/.
+    model_store: Any = None  # type: ignore[assignment]  # injected at runtime
+    __provider_id__: str = ""  # injected at runtime by the distribution system
+
     config: RemoteInferenceProviderConfig
 
     # Allow subclasses to control whether to overwrite the 'id' field in OpenAI responses
@@ -158,14 +163,14 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
         """
         if metadata := self.embedding_model_metadata.get(identifier):
             return Model(
-                provider_id=self.__provider_id__,  # type: ignore[attr-defined]
+                provider_id=self.__provider_id__,
                 provider_resource_id=identifier,
                 identifier=identifier,
                 model_type=ModelType.embedding,
                 metadata=metadata,
             )
         return Model(
-            provider_id=self.__provider_id__,  # type: ignore[attr-defined]
+            provider_id=self.__provider_id__,
             provider_resource_id=identifier,
             identifier=identifier,
             model_type=ModelType.llm,
@@ -290,11 +295,11 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
         :return: The provider-specific model ID (e.g., "gpt-4")
         """
         # self.model_store is injected by the distribution system at runtime
-        if not await self.model_store.has_model(model):  # type: ignore[attr-defined]
+        if not await self.model_store.has_model(model):
             return model
 
         # Look up the registered model to get the provider-specific model ID
-        model_obj: Model = await self.model_store.get_model(model)  # type: ignore[attr-defined]
+        model_obj: Model = await self.model_store.get_model(model)
         # provider_resource_id is str | None, but we expect it to be str for OpenAI calls
         if model_obj.provider_resource_id is None:
             raise ValueError(f"Model {model} has no provider_resource_id")
@@ -379,14 +384,14 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
             async def _localize_image_url(m: OpenAIMessageParam) -> OpenAIMessageParam:
                 if isinstance(m.content, list):
                     for c in m.content:
-                        if c.type == "image_url" and c.image_url and c.image_url.url and "http" in c.image_url.url:
-                            localize_result = await localize_image_content(c.image_url.url)
+                        if c.type == "image_url" and hasattr(c, "image_url") and c.image_url and c.image_url.url and "http" in c.image_url.url:  # ty: ignore[unresolved-attribute]
+                            localize_result = await localize_image_content(c.image_url.url)  # ty: ignore[unresolved-attribute]
                             if localize_result is None:
                                 raise ValueError(
-                                    f"Failed to localize image content from {c.image_url.url[:42]}{'...' if len(c.image_url.url) > 42 else ''}"
+                                    f"Failed to localize image content from {c.image_url.url[:42]}{'...' if len(c.image_url.url) > 42 else ''}"  # ty: ignore[unresolved-attribute]
                                 )
                             content, format = localize_result
-                            c.image_url.url = f"data:image/{format};base64,{base64.b64encode(content).decode('utf-8')}"
+                            c.image_url.url = f"data:image/{format};base64,{base64.b64encode(content).decode('utf-8')}"  # ty: ignore[invalid-assignment]
                 # else it's a string and we don't need to modify it
                 return m
 
@@ -501,7 +506,7 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
             return model
 
         if not await self.check_model_availability(model.provider_model_id):
-            raise ValueError(f"Model {model.provider_model_id} is not available from provider {self.__provider_id__}")  # type: ignore[attr-defined]
+            raise ValueError(f"Model {model.provider_model_id} is not available from provider {self.__provider_id__}")
         return model
 
     async def unregister_model(self, model_id: str) -> None:
@@ -562,7 +567,7 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
         """
         # First check if the model is pre-registered in the model store
         if hasattr(self, "model_store") and self.model_store:
-            qualified_model = f"{self.__provider_id__}/{model}"  # type: ignore[attr-defined]
+            qualified_model = f"{self.__provider_id__}/{model}"
             if await self.model_store.has_model(qualified_model):
                 return True
 

--- a/src/llama_stack/providers/utils/inference/openai_mixin.py
+++ b/src/llama_stack/providers/utils/inference/openai_mixin.py
@@ -386,7 +386,12 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
             async def _localize_image_url(m: OpenAIMessageParam) -> OpenAIMessageParam:
                 if isinstance(m.content, list):
                     for c in m.content:
-                        if isinstance(c, OpenAIChatCompletionContentPartImageParam) and c.image_url and c.image_url.url and "http" in c.image_url.url:
+                        if (
+                            isinstance(c, OpenAIChatCompletionContentPartImageParam)
+                            and c.image_url
+                            and c.image_url.url
+                            and "http" in c.image_url.url
+                        ):
                             localize_result = await localize_image_content(c.image_url.url)
                             if localize_result is None:
                                 raise ValueError(


### PR DESCRIPTION
## Summary
- Add `ty: ignore[unresolved-import]` comments to third-party imports (boto3, botocore, sentence_transformers, torch) across bedrock and inference utils
- Declare `model_store` and `__provider_id__` as class-level attributes on `OpenAIMixin` to fix undeclared attribute errors
- Add `None` guard for `model.provider_resource_id` in `ModelRegistryHelper.register_model`
- Fix `session_ttl` `int | None` → `int` type mismatch in bedrock client by providing default fallback
- Fix `str.join` overload mismatch with dict keys by using list comprehension
- Use `isinstance(c, OpenAIChatCompletionContentPartImageParam)` for proper type narrowing in image URL localization
- Add `config: Any` type declaration on `SentenceTransformerEmbeddingMixin`

## Test plan
- [x] `ty check` passes with zero errors on all in-scope files
- [x] 1647 unit tests pass (3 skipped, pre-existing import errors excluded)

Build times: ty check 0.17s, pytest 44s

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)