### PR TITLE
style: fix import ordering and ruff formatting in routing dispatch layer

### DIFF
--- a/src/llama_stack/core/routers/inference.py
+++ b/src/llama_stack/core/routers/inference.py
@@ -7,14 +7,12 @@
 import asyncio
 import time
 from collections.abc import AsyncIterator
-from typing import Annotated, Any
+from typing import Annotated, Any, cast
 
 from fastapi import Body
 from openai.types.chat import ChatCompletionToolChoiceOptionParam as OpenAIChatCompletionToolChoiceOptionParam
 from openai.types.chat import ChatCompletionToolParam as OpenAIChatCompletionToolParam
 from pydantic import TypeAdapter
-
-from typing import cast
 
 from llama_stack.core.access_control.access_control import is_action_allowed
 from llama_stack.core.access_control.conditions import ProtectedResource

--- a/src/llama_stack/core/routing_tables/common.py
+++ b/src/llama_stack/core/routing_tables/common.py
@@ -286,7 +286,9 @@ class CommonRoutingTableImpl(RoutingTable):
         # Apply attribute-based access control filtering
         if filtered_objs:
             filtered_objs = [
-                obj for obj in filtered_objs if is_action_allowed(self.policy, Action.READ, cast(ProtectedResource, obj), get_authenticated_user())
+                obj
+                for obj in filtered_objs
+                if is_action_allowed(self.policy, Action.READ, cast(ProtectedResource, obj), get_authenticated_user())
             ]
 
         return filtered_objs

--- a/src/llama_stack/core/routing_tables/scoring_functions.py
+++ b/src/llama_stack/core/routing_tables/scoring_functions.py
@@ -31,7 +31,9 @@ class ScoringFunctionsRoutingTable(CommonRoutingTableImpl, ScoringFunctions):
     """Routing table for managing scoring function registrations and provider lookups."""
 
     async def list_scoring_functions(self, request: ListScoringFunctionsRequest) -> ListScoringFunctionsResponse:
-        return ListScoringFunctionsResponse(data=cast(list[ScoringFn], await self.get_all_with_type(ResourceType.scoring_function.value)))
+        return ListScoringFunctionsResponse(
+            data=cast(list[ScoringFn], await self.get_all_with_type(ResourceType.scoring_function.value))
+        )
 
     async def get_scoring_function(self, request: GetScoringFunctionRequest) -> ScoringFn:
         scoring_fn = await self.get_object_by_identifier("scoring_function", request.scoring_fn_id)


### PR DESCRIPTION
## Summary
- Fix ruff import ordering in `inference.py` (merge `from typing import cast` into existing typing import)
- Fix ruff formatting in `common.py` and `scoring_functions.py`

These were in the second commit of PR #98 but didn't make it into the merged version.

## Test plan
- [x] `uv run ruff check` — 0 errors
- [x] `uv run ruff format --check` — 0 reformats needed
- [x] `ty check` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)