### PR TITLE
fix: add type annotations to remote inference providers

### DIFF
--- a/src/llama_stack/providers/remote/inference/bedrock/__init__.py
+++ b/src/llama_stack/providers/remote/inference/bedrock/__init__.py
@@ -3,10 +3,12 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
+from typing import Any
+
 from .config import BedrockConfig
 
 
-async def get_adapter_impl(config: BedrockConfig, _deps):
+async def get_adapter_impl(config: BedrockConfig, _deps: dict[str, Any]) -> Any:
     from .bedrock import BedrockInferenceAdapter
 
     assert isinstance(config, BedrockConfig), f"Unexpected config type: {type(config)}"

--- a/src/llama_stack/providers/remote/inference/nvidia/__init__.py
+++ b/src/llama_stack/providers/remote/inference/nvidia/__init__.py
@@ -4,12 +4,12 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-from llama_stack_api import Inference
+from typing import Any
 
 from .config import NVIDIAConfig
 
 
-async def get_adapter_impl(config: NVIDIAConfig, _deps) -> Inference:
+async def get_adapter_impl(config: NVIDIAConfig, _deps: dict[str, Any]) -> Any:
     # import dynamically so `llama stack list-deps` does not fail due to missing dependencies
     from .nvidia import NVIDIAInferenceAdapter
 

--- a/src/llama_stack/providers/remote/inference/nvidia/config.py
+++ b/src/llama_stack/providers/remote/inference/nvidia/config.py
@@ -46,7 +46,7 @@ class NVIDIAConfig(RemoteInferenceProviderConfig):
     URL of your running NVIDIA NIM and do not need to set the api_key.
     """
 
-    base_url: HttpUrl | None = Field(
+    base_url: HttpUrl | None = Field(  # ty: ignore[invalid-assignment]  # Pydantic Field() is not understood by ty
         default_factory=lambda: os.getenv("NVIDIA_BASE_URL", "https://integrate.api.nvidia.com/v1"),
         description="A base url for accessing the NVIDIA NIM",
     )
@@ -66,7 +66,7 @@ class NVIDIAConfig(RemoteInferenceProviderConfig):
     @classmethod
     def sample_run_config(
         cls,
-        base_url: HttpUrl | None = "${env.NVIDIA_BASE_URL:=https://integrate.api.nvidia.com/v1}",
+        base_url: str = "${env.NVIDIA_BASE_URL:=https://integrate.api.nvidia.com/v1}",
         api_key: str = "${env.NVIDIA_API_KEY:=}",
         **kwargs,
     ) -> dict[str, Any]:

--- a/src/llama_stack/providers/remote/inference/nvidia/nvidia.py
+++ b/src/llama_stack/providers/remote/inference/nvidia/nvidia.py
@@ -54,7 +54,7 @@ class NVIDIAInferenceAdapter(OpenAIMixin):
                     "API key is required for hosted NVIDIA NIM. Either provide an API key or use a self-hosted NIM."
                 )
 
-    def get_api_key(self) -> str:
+    def get_api_key(self) -> str | None:
         """
         Get the API key for OpenAI mixin.
 
@@ -96,7 +96,7 @@ class NVIDIAInferenceAdapter(OpenAIMixin):
         """
         if identifier in self.config.rerank_model_to_url:
             return Model(
-                provider_id=self.__provider_id__,  # type: ignore[attr-defined]
+                provider_id=self.__provider_id__,  # ty: ignore[unresolved-attribute]  # runtime-injected by routing table
                 provider_resource_id=identifier,
                 identifier=identifier,
                 model_type=ModelType.rerank,

--- a/src/llama_stack/providers/remote/inference/oci/__init__.py
+++ b/src/llama_stack/providers/remote/inference/oci/__init__.py
@@ -4,12 +4,12 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-from llama_stack_api import InferenceProvider
+from typing import Any
 
 from .config import OCIConfig
 
 
-async def get_adapter_impl(config: OCIConfig, _deps) -> InferenceProvider:
+async def get_adapter_impl(config: OCIConfig, _deps: dict[str, Any]) -> Any:
     from .oci import OCIInferenceAdapter
 
     adapter = OCIInferenceAdapter(config=config)

--- a/src/llama_stack/providers/remote/inference/oci/auth.py
+++ b/src/llama_stack/providers/remote/inference/oci/auth.py
@@ -68,7 +68,7 @@ class OciUserPrincipalAuth(HttpxOciAuth):
 
     def __init__(self, config_file: str = DEFAULT_LOCATION, profile_name: str = DEFAULT_PROFILE):
         config = oci.config.from_file(config_file, profile_name)
-        oci.config.validate_config(config)  # type: ignore
+        oci.config.validate_config(config)
         key_content = ""
         with open(config["key_file"]) as f:
             key_content = f.read()
@@ -78,6 +78,6 @@ class OciUserPrincipalAuth(HttpxOciAuth):
             user=config["user"],
             fingerprint=config["fingerprint"],
             private_key_file_location=config.get("key_file"),
-            pass_phrase="none",  # type: ignore
+            pass_phrase="none",
             private_key_content=key_content,
         )

--- a/src/llama_stack/providers/remote/inference/oci/oci.py
+++ b/src/llama_stack/providers/remote/inference/oci/oci.py
@@ -152,13 +152,13 @@ class OCIInferenceAdapter(OpenAIMixin):
         """
         if identifier in self.embedding_models:
             return Model(
-                provider_id=self.__provider_id__,  # type: ignore[attr-defined]
+                provider_id=self.__provider_id__,  # ty: ignore[unresolved-attribute]  # runtime-injected by routing table
                 provider_resource_id=identifier,
                 identifier=identifier,
                 model_type=ModelType.embedding,
             )
         return Model(
-            provider_id=self.__provider_id__,  # type: ignore[attr-defined]
+            provider_id=self.__provider_id__,  # ty: ignore[unresolved-attribute]  # runtime-injected by routing table
             provider_resource_id=identifier,
             identifier=identifier,
             model_type=ModelType.llm,

--- a/src/llama_stack/providers/remote/inference/passthrough/__init__.py
+++ b/src/llama_stack/providers/remote/inference/passthrough/__init__.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+from typing import Any
+
 from pydantic import BaseModel, ConfigDict, HttpUrl, SecretStr
 
 from .config import PassthroughImplConfig
@@ -24,7 +26,7 @@ class PassthroughProviderDataValidator(BaseModel):
     passthrough_api_key: SecretStr | None = None
 
 
-async def get_adapter_impl(config: PassthroughImplConfig, _deps):
+async def get_adapter_impl(config: PassthroughImplConfig, _deps: dict[str, Any]) -> Any:
     from .passthrough import PassthroughInferenceAdapter
 
     if not isinstance(config, PassthroughImplConfig):

--- a/src/llama_stack/providers/remote/inference/passthrough/config.py
+++ b/src/llama_stack/providers/remote/inference/passthrough/config.py
@@ -53,7 +53,7 @@ class PassthroughImplConfig(RemoteInferenceProviderConfig):
     @classmethod
     def sample_run_config(
         cls,
-        base_url: HttpUrl | None = "${env.PASSTHROUGH_URL}",
+        base_url: str = "${env.PASSTHROUGH_URL}",
         api_key: str = "${env.PASSTHROUGH_API_KEY:=}",
         forward_headers: dict[str, str] | None = None,
         extra_blocked_headers: list[str] | None = None,

--- a/src/llama_stack/providers/remote/inference/passthrough/passthrough.py
+++ b/src/llama_stack/providers/remote/inference/passthrough/passthrough.py
@@ -60,11 +60,11 @@ class PassthroughInferenceAdapter(NeedsRequestProviderData, Inference):
             custom_metadata = getattr(model_data, "custom_metadata", {}) or {}
 
             # Prefix identifier with provider ID for local registry
-            local_identifier = f"{self.__provider_id__}/{downstream_model_id}"
+            local_identifier = f"{self.__provider_id__}/{downstream_model_id}"  # ty: ignore[unresolved-attribute]  # runtime-injected by routing table
 
             model = Model(
                 identifier=local_identifier,
-                provider_id=self.__provider_id__,
+                provider_id=self.__provider_id__,  # ty: ignore[unresolved-attribute]  # runtime-injected by routing table
                 provider_resource_id=downstream_model_id,
                 model_type=custom_metadata.get("model_type", "llm"),
                 metadata=custom_metadata,
@@ -180,4 +180,4 @@ class PassthroughInferenceAdapter(NeedsRequestProviderData, Inference):
         client = self._get_openai_client()
         request_params = params.model_dump(exclude_none=True)
         response = await client.embeddings.create(**request_params)
-        return response  # type: ignore
+        return response  # ty: ignore[invalid-return-type]  # OpenAI SDK returns compatible type

--- a/src/llama_stack/providers/remote/inference/runpod/__init__.py
+++ b/src/llama_stack/providers/remote/inference/runpod/__init__.py
@@ -4,10 +4,12 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+from typing import Any
+
 from .config import RunpodImplConfig
 
 
-async def get_adapter_impl(config: RunpodImplConfig, _deps):
+async def get_adapter_impl(config: RunpodImplConfig, _deps: dict[str, Any]) -> Any:
     from .runpod import RunpodInferenceAdapter
 
     assert isinstance(config, RunpodImplConfig), f"Unexpected config type: {type(config)}"

--- a/src/llama_stack/providers/remote/inference/watsonx/__init__.py
+++ b/src/llama_stack/providers/remote/inference/watsonx/__init__.py
@@ -4,10 +4,12 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+from typing import Any
+
 from .config import WatsonXConfig
 
 
-async def get_adapter_impl(config: WatsonXConfig, _deps):
+async def get_adapter_impl(config: WatsonXConfig, _deps: dict[str, Any]) -> Any:
     # import dynamically so the import is used only when it is needed
     from .watsonx import WatsonXInferenceAdapter
 

--- a/src/llama_stack/providers/remote/inference/watsonx/config.py
+++ b/src/llama_stack/providers/remote/inference/watsonx/config.py
@@ -27,7 +27,7 @@ class WatsonXProviderDataValidator(BaseModel):
 class WatsonXConfig(RemoteInferenceProviderConfig):
     """Configuration for the IBM WatsonX inference provider."""
 
-    base_url: HttpUrl | None = Field(
+    base_url: HttpUrl | None = Field(  # ty: ignore[invalid-assignment]  # Pydantic Field() is not understood by ty
         default_factory=lambda: os.getenv("WATSONX_BASE_URL", "https://us-south.ml.cloud.ibm.com"),
         description="A base url for accessing the watsonx.ai",
     )

--- a/src/llama_stack/providers/remote/inference/watsonx/watsonx.py
+++ b/src/llama_stack/providers/remote/inference/watsonx/watsonx.py
@@ -35,6 +35,8 @@ WATSONX_API_VERSION = "2023-10-25"
 class WatsonXInferenceAdapter(OpenAIMixin):
     """Inference adapter for IBM WatsonX AI platform."""
 
+    config: WatsonXConfig  # narrow from parent's RemoteInferenceProviderConfig
+
     _model_cache: dict[str, Model] = {}
 
     provider_data_api_key_field: str = "watsonx_api_key"
@@ -163,7 +165,7 @@ class WatsonXInferenceAdapter(OpenAIMixin):
                 break
 
         return Model(
-            provider_id=self.__provider_id__,
+            provider_id=self.__provider_id__,  # ty: ignore[unresolved-attribute]  # runtime-injected by routing table
             provider_resource_id=identifier,
             identifier=identifier,
             model_type=model_type,


### PR DESCRIPTION
## Summary
- Add proper type annotations to all 6 remote inference provider directories (bedrock, nvidia, oci, passthrough, runpod, watsonx) so they pass `ty check` with zero errors
- Fix return types, parameter annotations, runtime-injected attribute suppressions, and Pydantic Field assignment suppressions
- All 14 files modified are annotation-only changes — no runtime behavior changed

## Changes
- Add return type and parameter annotations to all `get_adapter_impl` functions
- Fix `get_api_key` return type in nvidia to `str | None` (can return None)
- Add `ty: ignore[unresolved-attribute]` for runtime-injected `__provider_id__`
- Add `ty: ignore[invalid-assignment]` for Pydantic `Field()` assignments not understood by ty
- Remove unused blanket `type: ignore` comments in `oci/auth.py`
- Fix `sample_run_config` parameter types (`str` instead of `HttpUrl` for template strings)
- Declare `config: WatsonXConfig` on `WatsonXInferenceAdapter` to narrow parent type
- Add `ty: ignore[invalid-return-type]` for OpenAI SDK return value mismatches

## Verification
- `ty check` on all 6 provider directories: **0 errors** (ty check: 0.3s)
- Unit tests: **574 passed** (5.85s)

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)