### PR TITLE
Add type annotations to remote inference providers

### DIFF
--- a/src/llama_stack/providers/remote/inference/bedrock/__init__.py
+++ b/src/llama_stack/providers/remote/inference/bedrock/__init__.py
@@ -3,10 +3,18 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 from .config import BedrockConfig
 
+if TYPE_CHECKING:
+    from .bedrock import BedrockInferenceAdapter
 
-async def get_adapter_impl(config: BedrockConfig, _deps):
+
+async def get_adapter_impl(config: BedrockConfig, _deps: dict[str, Any]) -> BedrockInferenceAdapter:
     from .bedrock import BedrockInferenceAdapter
 
     assert isinstance(config, BedrockConfig), f"Unexpected config type: {type(config)}"

--- a/src/llama_stack/providers/remote/inference/bedrock/config.py
+++ b/src/llama_stack/providers/remote/inference/bedrock/config.py
@@ -5,6 +5,7 @@
 # the root directory of this source tree.
 
 import os
+from typing import Any
 
 from pydantic import BaseModel, Field, SecretStr
 
@@ -29,7 +30,7 @@ class BedrockConfig(RemoteInferenceProviderConfig):
     )
 
     @classmethod
-    def sample_run_config(cls, **kwargs):
+    def sample_run_config(cls, **kwargs: Any) -> dict[str, Any]:
         return {
             "api_key": "${env.AWS_BEARER_TOKEN_BEDROCK:=}",
             "region_name": "${env.AWS_DEFAULT_REGION:=us-east-2}",

--- a/src/llama_stack/providers/remote/inference/nvidia/__init__.py
+++ b/src/llama_stack/providers/remote/inference/nvidia/__init__.py
@@ -4,12 +4,17 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-from llama_stack_api import Inference
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from .config import NVIDIAConfig
 
+if TYPE_CHECKING:
+    from .nvidia import NVIDIAInferenceAdapter
 
-async def get_adapter_impl(config: NVIDIAConfig, _deps) -> Inference:
+
+async def get_adapter_impl(config: NVIDIAConfig, _deps: dict[str, Any]) -> NVIDIAInferenceAdapter:
     # import dynamically so `llama stack list-deps` does not fail due to missing dependencies
     from .nvidia import NVIDIAInferenceAdapter
 

--- a/src/llama_stack/providers/remote/inference/nvidia/config.py
+++ b/src/llama_stack/providers/remote/inference/nvidia/config.py
@@ -46,7 +46,7 @@ class NVIDIAConfig(RemoteInferenceProviderConfig):
     URL of your running NVIDIA NIM and do not need to set the api_key.
     """
 
-    base_url: HttpUrl | None = Field(
+    base_url: HttpUrl | None = Field(  # ty: ignore[invalid-assignment]
         default_factory=lambda: os.getenv("NVIDIA_BASE_URL", "https://integrate.api.nvidia.com/v1"),
         description="A base url for accessing the NVIDIA NIM",
     )
@@ -66,9 +66,9 @@ class NVIDIAConfig(RemoteInferenceProviderConfig):
     @classmethod
     def sample_run_config(
         cls,
-        base_url: HttpUrl | None = "${env.NVIDIA_BASE_URL:=https://integrate.api.nvidia.com/v1}",
+        base_url: str = "${env.NVIDIA_BASE_URL:=https://integrate.api.nvidia.com/v1}",
         api_key: str = "${env.NVIDIA_API_KEY:=}",
-        **kwargs,
+        **kwargs: Any,
     ) -> dict[str, Any]:
         return {
             "base_url": base_url,

--- a/src/llama_stack/providers/remote/inference/nvidia/nvidia.py
+++ b/src/llama_stack/providers/remote/inference/nvidia/nvidia.py
@@ -29,6 +29,8 @@ logger = get_logger(name=__name__, category="inference::nvidia")
 class NVIDIAInferenceAdapter(OpenAIMixin):
     """Inference adapter for NVIDIA NIM models and services."""
 
+    __provider_id__: str = ""  # runtime-injected by the routing table
+
     config: NVIDIAConfig
 
     provider_data_api_key_field: str = "nvidia_api_key"
@@ -54,7 +56,7 @@ class NVIDIAInferenceAdapter(OpenAIMixin):
                     "API key is required for hosted NVIDIA NIM. Either provide an API key or use a self-hosted NIM."
                 )
 
-    def get_api_key(self) -> str:
+    def get_api_key(self) -> str | None:
         """
         Get the API key for OpenAI mixin.
 
@@ -96,7 +98,7 @@ class NVIDIAInferenceAdapter(OpenAIMixin):
         """
         if identifier in self.config.rerank_model_to_url:
             return Model(
-                provider_id=self.__provider_id__,  # type: ignore[attr-defined]
+                provider_id=self.__provider_id__,
                 provider_resource_id=identifier,
                 identifier=identifier,
                 model_type=ModelType.rerank,

--- a/src/llama_stack/providers/remote/inference/oci/__init__.py
+++ b/src/llama_stack/providers/remote/inference/oci/__init__.py
@@ -4,12 +4,17 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-from llama_stack_api import InferenceProvider
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from .config import OCIConfig
 
+if TYPE_CHECKING:
+    from .oci import OCIInferenceAdapter
 
-async def get_adapter_impl(config: OCIConfig, _deps) -> InferenceProvider:
+
+async def get_adapter_impl(config: OCIConfig, _deps: dict[str, Any]) -> OCIInferenceAdapter:
     from .oci import OCIInferenceAdapter
 
     adapter = OCIInferenceAdapter(config=config)

--- a/src/llama_stack/providers/remote/inference/oci/auth.py
+++ b/src/llama_stack/providers/remote/inference/oci/auth.py
@@ -8,9 +8,9 @@ from collections.abc import Generator, Mapping
 from typing import Any, override
 
 import httpx
-import oci
+import oci  # type: ignore[import-untyped]  # ty: ignore[unresolved-import]
 import requests
-from oci.config import DEFAULT_LOCATION, DEFAULT_PROFILE
+from oci.config import DEFAULT_LOCATION, DEFAULT_PROFILE  # type: ignore[import-untyped]  # ty: ignore[unresolved-import]
 
 OciAuthSigner = type[oci.signer.AbstractBaseSigner]
 
@@ -48,7 +48,7 @@ class HttpxOciAuth(httpx.Auth):
         prepared_request = req.prepare()
 
         # Sign the request using the OCI Signer
-        self.signer.do_request_sign(prepared_request)  # type: ignore
+        self.signer.do_request_sign(prepared_request)  # type: ignore[union-attr]
 
         # Update the original HTTPX request with the signed headers
         request.headers.update(prepared_request.headers)
@@ -68,7 +68,7 @@ class OciUserPrincipalAuth(HttpxOciAuth):
 
     def __init__(self, config_file: str = DEFAULT_LOCATION, profile_name: str = DEFAULT_PROFILE):
         config = oci.config.from_file(config_file, profile_name)
-        oci.config.validate_config(config)  # type: ignore
+        oci.config.validate_config(config)  # type: ignore[no-untyped-call]
         key_content = ""
         with open(config["key_file"]) as f:
             key_content = f.read()
@@ -78,6 +78,6 @@ class OciUserPrincipalAuth(HttpxOciAuth):
             user=config["user"],
             fingerprint=config["fingerprint"],
             private_key_file_location=config.get("key_file"),
-            pass_phrase="none",  # type: ignore
+            pass_phrase="none",  # type: ignore[arg-type]
             private_key_content=key_content,
         )

--- a/src/llama_stack/providers/remote/inference/oci/oci.py
+++ b/src/llama_stack/providers/remote/inference/oci/oci.py
@@ -9,9 +9,9 @@ from collections.abc import Iterable
 from typing import Any
 
 import httpx
-import oci
-from oci.generative_ai.generative_ai_client import GenerativeAiClient
-from oci.generative_ai.models import ModelCollection
+import oci  # type: ignore[import-untyped]  # ty: ignore[unresolved-import]
+from oci.generative_ai.generative_ai_client import GenerativeAiClient  # type: ignore[import-untyped]  # ty: ignore[unresolved-import]
+from oci.generative_ai.models import ModelCollection  # type: ignore[import-untyped]  # ty: ignore[unresolved-import]
 from openai import DefaultAsyncHttpxClient
 
 from llama_stack.log import get_logger
@@ -32,6 +32,8 @@ MODEL_CAPABILITIES = ["TEXT_GENERATION", "TEXT_SUMMARIZATION", "TEXT_EMBEDDINGS"
 
 class OCIInferenceAdapter(OpenAIMixin):
     """Inference adapter for Oracle Cloud Infrastructure Generative AI."""
+
+    __provider_id__: str = ""  # runtime-injected by the routing table
 
     config: OCIConfig
 
@@ -78,7 +80,7 @@ class OCIInferenceAdapter(OpenAIMixin):
             return oci.auth.signers.InstancePrincipalsSecurityTokenSigner()
         return None
 
-    def _get_oci_config(self) -> dict:
+    def _get_oci_config(self) -> dict[str, Any]:
         if self.config.oci_auth_type == OCI_AUTH_TYPE_INSTANCE_PRINCIPAL:
             config = {"region": self.config.oci_region}
         elif self.config.oci_auth_type == OCI_AUTH_TYPE_CONFIG_FILE:
@@ -152,13 +154,13 @@ class OCIInferenceAdapter(OpenAIMixin):
         """
         if identifier in self.embedding_models:
             return Model(
-                provider_id=self.__provider_id__,  # type: ignore[attr-defined]
+                provider_id=self.__provider_id__,
                 provider_resource_id=identifier,
                 identifier=identifier,
                 model_type=ModelType.embedding,
             )
         return Model(
-            provider_id=self.__provider_id__,  # type: ignore[attr-defined]
+            provider_id=self.__provider_id__,
             provider_resource_id=identifier,
             identifier=identifier,
             model_type=ModelType.llm,

--- a/src/llama_stack/providers/remote/inference/passthrough/__init__.py
+++ b/src/llama_stack/providers/remote/inference/passthrough/__init__.py
@@ -4,9 +4,16 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 from pydantic import BaseModel, ConfigDict, HttpUrl, SecretStr
 
 from .config import PassthroughImplConfig
+
+if TYPE_CHECKING:
+    from .passthrough import PassthroughInferenceAdapter
 
 
 class PassthroughProviderDataValidator(BaseModel):
@@ -24,7 +31,7 @@ class PassthroughProviderDataValidator(BaseModel):
     passthrough_api_key: SecretStr | None = None
 
 
-async def get_adapter_impl(config: PassthroughImplConfig, _deps):
+async def get_adapter_impl(config: PassthroughImplConfig, _deps: dict[str, Any]) -> PassthroughInferenceAdapter:
     from .passthrough import PassthroughInferenceAdapter
 
     if not isinstance(config, PassthroughImplConfig):

--- a/src/llama_stack/providers/remote/inference/passthrough/config.py
+++ b/src/llama_stack/providers/remote/inference/passthrough/config.py
@@ -53,11 +53,11 @@ class PassthroughImplConfig(RemoteInferenceProviderConfig):
     @classmethod
     def sample_run_config(
         cls,
-        base_url: HttpUrl | None = "${env.PASSTHROUGH_URL}",
+        base_url: str = "${env.PASSTHROUGH_URL}",
         api_key: str = "${env.PASSTHROUGH_API_KEY:=}",
         forward_headers: dict[str, str] | None = None,
         extra_blocked_headers: list[str] | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> dict[str, Any]:
         config: dict[str, Any] = {
             "base_url": base_url,

--- a/src/llama_stack/providers/remote/inference/passthrough/passthrough.py
+++ b/src/llama_stack/providers/remote/inference/passthrough/passthrough.py
@@ -32,6 +32,8 @@ logger = get_logger(__name__, category="inference")
 class PassthroughInferenceAdapter(NeedsRequestProviderData, Inference):
     """Inference adapter that forwards requests to any OpenAI-compatible endpoint."""
 
+    __provider_id__: str = ""  # runtime-injected by the routing table
+
     def __init__(self, config: PassthroughImplConfig) -> None:
         self.config = config
 
@@ -180,4 +182,4 @@ class PassthroughInferenceAdapter(NeedsRequestProviderData, Inference):
         client = self._get_openai_client()
         request_params = params.model_dump(exclude_none=True)
         response = await client.embeddings.create(**request_params)
-        return response  # type: ignore
+        return response  # type: ignore[return-value]  # ty: ignore[invalid-return-type]

--- a/src/llama_stack/providers/remote/inference/runpod/__init__.py
+++ b/src/llama_stack/providers/remote/inference/runpod/__init__.py
@@ -4,10 +4,17 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 from .config import RunpodImplConfig
 
+if TYPE_CHECKING:
+    from .runpod import RunpodInferenceAdapter
 
-async def get_adapter_impl(config: RunpodImplConfig, _deps):
+
+async def get_adapter_impl(config: RunpodImplConfig, _deps: dict[str, Any]) -> RunpodInferenceAdapter:
     from .runpod import RunpodInferenceAdapter
 
     assert isinstance(config, RunpodImplConfig), f"Unexpected config type: {type(config)}"

--- a/src/llama_stack/providers/remote/inference/watsonx/__init__.py
+++ b/src/llama_stack/providers/remote/inference/watsonx/__init__.py
@@ -4,10 +4,17 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 from .config import WatsonXConfig
 
+if TYPE_CHECKING:
+    from .watsonx import WatsonXInferenceAdapter
 
-async def get_adapter_impl(config: WatsonXConfig, _deps):
+
+async def get_adapter_impl(config: WatsonXConfig, _deps: dict[str, Any]) -> WatsonXInferenceAdapter:
     # import dynamically so the import is used only when it is needed
     from .watsonx import WatsonXInferenceAdapter
 

--- a/src/llama_stack/providers/remote/inference/watsonx/config.py
+++ b/src/llama_stack/providers/remote/inference/watsonx/config.py
@@ -27,7 +27,7 @@ class WatsonXProviderDataValidator(BaseModel):
 class WatsonXConfig(RemoteInferenceProviderConfig):
     """Configuration for the IBM WatsonX inference provider."""
 
-    base_url: HttpUrl | None = Field(
+    base_url: HttpUrl | None = Field(  # ty: ignore[invalid-assignment]
         default_factory=lambda: os.getenv("WATSONX_BASE_URL", "https://us-south.ml.cloud.ibm.com"),
         description="A base url for accessing the watsonx.ai",
     )
@@ -41,7 +41,7 @@ class WatsonXConfig(RemoteInferenceProviderConfig):
     )
 
     @classmethod
-    def sample_run_config(cls, **kwargs) -> dict[str, Any]:
+    def sample_run_config(cls, **kwargs: Any) -> dict[str, Any]:
         return {
             "base_url": "${env.WATSONX_BASE_URL:=https://us-south.ml.cloud.ibm.com}",
             "api_key": "${env.WATSONX_API_KEY:=}",

--- a/src/llama_stack/providers/remote/inference/watsonx/watsonx.py
+++ b/src/llama_stack/providers/remote/inference/watsonx/watsonx.py
@@ -35,6 +35,9 @@ WATSONX_API_VERSION = "2023-10-25"
 class WatsonXInferenceAdapter(OpenAIMixin):
     """Inference adapter for IBM WatsonX AI platform."""
 
+    __provider_id__: str = ""  # runtime-injected by the routing table
+    config: WatsonXConfig
+
     _model_cache: dict[str, Model] = {}
 
     provider_data_api_key_field: str = "watsonx_api_key"


### PR DESCRIPTION
## Summary
- Add proper type annotations to all `get_adapter_impl` functions across 6 remote inference providers (bedrock, nvidia, oci, passthrough, runpod, watsonx)
- Declare `__provider_id__: str` as a class attribute on adapter classes that access it at runtime (nvidia, oci, passthrough, watsonx)
- Fix `nvidia.get_api_key()` return type from `str` to `str | None` to match actual behavior
- Add `# ty: ignore` comments for pydantic Field assignments that ty can't resolve and untyped SDK imports (oci)
- Replace bare `# type: ignore` comments with error-code-qualified versions
- Fix `sample_run_config` parameter types to use `str` instead of `HttpUrl` for template string defaults

## Verification
- `ty check` passes with zero errors on all 6 provider directories
- 1592 unit tests pass (pre-existing collection errors from missing optional deps are unrelated)

## Test plan
- [x] `ty check` passes with zero errors
- [x] `uv run pytest tests/unit/` passes (1592 passed, 3 skipped)
- [x] No new bare `# type: ignore` without error codes
- [x] No behavioral changes — annotation-only

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)