### PR TITLE
fix: remove unused ty:ignore on sqlalchemy import in inference_store.py

### DIFF
--- a/src/llama_stack/providers/utils/inference/inference_store.py
+++ b/src/llama_stack/providers/utils/inference/inference_store.py
@@ -6,7 +6,7 @@
 import asyncio
 from typing import Any, NamedTuple
 
-from sqlalchemy.exc import IntegrityError  # ty: ignore[unresolved-import]
+from sqlalchemy.exc import IntegrityError
 
 from llama_stack.core.datatypes import AccessRule
 from llama_stack.core.storage.datatypes import InferenceStoreReference, StorageBackendType


### PR DESCRIPTION
## Summary
- Remove unused `ty: ignore[unresolved-import]` on `sqlalchemy.exc.IntegrityError` import
- This was the last remaining `ty check` error for milestone 3 (shared inference utilities)

## Verification
- `ty check` on all milestone 3 files: **0 errors**

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)