### PR TITLE
fix: resolve 23 remaining ty check errors in remote inference providers

### DIFF
--- a/src/llama_stack/providers/remote/inference/databricks/databricks.py
+++ b/src/llama_stack/providers/remote/inference/databricks/databricks.py
@@ -6,7 +6,7 @@
 
 from collections.abc import AsyncIterator, Iterable
 
-from databricks.sdk import WorkspaceClient
+from databricks.sdk import WorkspaceClient  # ty: ignore[unresolved-import]
 
 from llama_stack.log import get_logger
 from llama_stack.providers.utils.inference.openai_mixin import OpenAIMixin

--- a/src/llama_stack/providers/remote/inference/ollama/__init__.py
+++ b/src/llama_stack/providers/remote/inference/ollama/__init__.py
@@ -10,6 +10,6 @@ from .config import OllamaImplConfig
 async def get_adapter_impl(config: OllamaImplConfig, _deps):
     from .ollama import OllamaInferenceAdapter
 
-    impl = OllamaInferenceAdapter(config=config)
+    impl = OllamaInferenceAdapter(config=config)  # ty: ignore[missing-argument]
     await impl.initialize()
     return impl

--- a/src/llama_stack/providers/remote/inference/ollama/ollama.py
+++ b/src/llama_stack/providers/remote/inference/ollama/ollama.py
@@ -7,7 +7,7 @@
 
 import asyncio
 
-from ollama import AsyncClient as AsyncOllamaClient
+from ollama import AsyncClient as AsyncOllamaClient  # ty: ignore[unresolved-import]
 
 from llama_stack.log import get_logger
 from llama_stack.providers.remote.inference.ollama.config import OllamaImplConfig

--- a/src/llama_stack/providers/remote/inference/together/together.py
+++ b/src/llama_stack/providers/remote/inference/together/together.py
@@ -8,7 +8,7 @@
 from collections.abc import Iterable
 from typing import Any, cast
 
-from together import AsyncTogether  # type: ignore[import-untyped]
+from together import AsyncTogether  # ty: ignore[unresolved-import]
 
 from llama_stack.core.request_headers import NeedsRequestProviderData
 from llama_stack.log import get_logger

--- a/src/llama_stack/providers/remote/inference/vertexai/converters.py
+++ b/src/llama_stack/providers/remote/inference/vertexai/converters.py
@@ -48,7 +48,7 @@ from llama_stack_api.inference.models import (
 logger = get_logger(__name__, category="inference")
 
 if TYPE_CHECKING:
-    from google.genai import types as genai_types
+    from google.genai import types as genai_types  # ty: ignore[unresolved-import]
 
 
 def _to_dict(obj: Any) -> dict[str, Any]:
@@ -671,7 +671,7 @@ def convert_gemini_stream_chunk_to_openai(
             delta=OpenAIChoiceDelta(
                 role=role,
                 content=cd.text,
-                tool_calls=cd.tool_calls or None,  # type: ignore[arg-type]
+                tool_calls=cd.tool_calls or None,  # ty: ignore[invalid-argument-type]
                 reasoning_content=cd.reasoning_content,
             ),
             finish_reason=_resolve_stream_finish_reason(cd.finish_reason_raw, bool(cd.tool_calls)),

--- a/src/llama_stack/providers/remote/inference/vertexai/utils.py
+++ b/src/llama_stack/providers/remote/inference/vertexai/utils.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any
 
 import httpx
-from google.genai import types as genai_types
+from google.genai import types as genai_types  # ty: ignore[unresolved-import]
 
 from llama_stack.log import get_logger
 from llama_stack.providers.utils.inference.http_client import _build_proxy_mounts, _build_ssl_context

--- a/src/llama_stack/providers/remote/inference/vertexai/vertexai.py
+++ b/src/llama_stack/providers/remote/inference/vertexai/vertexai.py
@@ -12,9 +12,9 @@ import time
 from collections.abc import AsyncIterator
 from typing import Any, cast
 
-from google.genai import Client
-from google.genai import types as genai_types
-from google.oauth2.credentials import Credentials
+from google.genai import Client  # ty: ignore[unresolved-import]
+from google.genai import types as genai_types  # ty: ignore[unresolved-import]
+from google.oauth2.credentials import Credentials  # ty: ignore[unresolved-import]
 from pydantic import BaseModel, ConfigDict, PrivateAttr
 
 from llama_stack.core.request_headers import NeedsRequestProviderData
@@ -193,7 +193,7 @@ class VertexAIInferenceAdapter(NeedsRequestProviderData, BaseModel):
         provider_resource_id = model.provider_resource_id or model.identifier
         if not await self.check_model_availability(provider_resource_id):
             raise ValueError(
-                f"Model {provider_resource_id} is not available from provider {self.__provider_id__}"  # type: ignore[attr-defined]
+                f"Model {provider_resource_id} is not available from provider {self.__provider_id__}"  # ty: ignore[unresolved-attribute]
             )
         return model
 
@@ -296,8 +296,8 @@ class VertexAIInferenceAdapter(NeedsRequestProviderData, BaseModel):
 
     async def _get_provider_model_id(self, model: str) -> str:
         # model_store is injected at runtime by the routing infra
-        if hasattr(self, "model_store") and self.model_store and await self.model_store.has_model(model):  # type: ignore[attr-defined]
-            model_obj: Model = await self.model_store.get_model(model)  # type: ignore[attr-defined]
+        if hasattr(self, "model_store") and self.model_store and await self.model_store.has_model(model):  # ty: ignore[unresolved-attribute]
+            model_obj: Model = await self.model_store.get_model(model)  # ty: ignore[unresolved-attribute]
             if model_obj.provider_resource_id is None:
                 raise ValueError(f"Model {model} has no provider_resource_id")
             return model_obj.provider_resource_id
@@ -352,7 +352,7 @@ class VertexAIInferenceAdapter(NeedsRequestProviderData, BaseModel):
                 continue
             if metadata := self.embedding_model_metadata.get(provider_model_id):
                 model = Model(
-                    provider_id=self.__provider_id__,  # type: ignore[attr-defined]
+                    provider_id=self.__provider_id__,  # ty: ignore[unresolved-attribute]
                     provider_resource_id=provider_model_id,
                     identifier=provider_model_id,
                     model_type=ModelType.embedding,
@@ -360,7 +360,7 @@ class VertexAIInferenceAdapter(NeedsRequestProviderData, BaseModel):
                 )
             else:
                 model = Model(
-                    provider_id=self.__provider_id__,  # type: ignore[attr-defined]
+                    provider_id=self.__provider_id__,  # ty: ignore[unresolved-attribute]
                     provider_resource_id=provider_model_id,
                     identifier=provider_model_id,
                     model_type=ModelType.llm,
@@ -608,15 +608,15 @@ class VertexAIInferenceAdapter(NeedsRequestProviderData, BaseModel):
             for content_part in message.content:
                 if (
                     content_part.type == "image_url"
-                    and content_part.image_url
-                    and content_part.image_url.url
-                    and "http" in content_part.image_url.url
+                    and content_part.image_url  # ty: ignore[unresolved-attribute]
+                    and content_part.image_url.url  # ty: ignore[unresolved-attribute]
+                    and "http" in content_part.image_url.url  # ty: ignore[unresolved-attribute]
                 ):
-                    localize_result = await localize_image_content(content_part.image_url.url)
+                    localize_result = await localize_image_content(content_part.image_url.url)  # ty: ignore[unresolved-attribute]
                     if localize_result is None:
-                        raise ValueError(f"Failed to localize image content from URL: {content_part.image_url.url}")
+                        raise ValueError(f"Failed to localize image content from URL: {content_part.image_url.url}")  # ty: ignore[unresolved-attribute]
                     content, fmt = localize_result
-                    content_part.image_url.url = f"data:image/{fmt};base64,{base64.b64encode(content).decode('utf-8')}"
+                    content_part.image_url.url = f"data:image/{fmt};base64,{base64.b64encode(content).decode('utf-8')}"  # ty: ignore[unresolved-attribute]
 
         return message
 

--- a/src/llama_stack/providers/remote/inference/vllm/vllm.py
+++ b/src/llama_stack/providers/remote/inference/vllm/vllm.py
@@ -116,7 +116,7 @@ class VLLMInferenceAdapter(OpenAIMixin):
         # vLLM's /v1/models response does not expose a model task/type field, so classify by name.
         if "embed" in identifier.lower():
             return Model(
-                provider_id=self.__provider_id__,  # type: ignore[attr-defined]
+                provider_id=self.__provider_id__,  # ty: ignore[unresolved-attribute]
                 provider_resource_id=identifier,
                 identifier=identifier,
                 model_type=ModelType.embedding,
@@ -124,7 +124,7 @@ class VLLMInferenceAdapter(OpenAIMixin):
             )
         if "rerank" in identifier.lower():
             return Model(
-                provider_id=self.__provider_id__,  # type: ignore[attr-defined]
+                provider_id=self.__provider_id__,  # ty: ignore[unresolved-attribute]
                 provider_resource_id=identifier,
                 identifier=identifier,
                 model_type=ModelType.rerank,


### PR DESCRIPTION
## Summary
- Add `# ty: ignore[error-code]` annotations to resolve all 23 remaining type errors in `src/llama_stack/providers/remote/inference/`
- Fixes: databricks (1 unresolved-import), ollama (1 missing-argument + 1 unresolved-import), together (1 unresolved-import), vertexai (5 unresolved-import + 1 invalid-argument-type + 2 unresolved-attribute for model_store + 2 unresolved-attribute for __provider_id__ + 6 unresolved-attribute for image_url union narrowing), vllm (2 unresolved-attribute for __provider_id__)
- Annotation-only changes — no behavior modifications

## Test plan
- [x] `uvx ty@0.0.27 check` on remote inference providers: 0 errors
- [x] All 6 milestones pass ty check individually: 0 errors each
- [x] `uv run pytest tests/unit/` — 767 passed, 3 skipped (excluding pre-existing missing deps: chardet, ollama, boto3, torch)

Build times: ty check 0.3s, pytest 14s

🤖 Generated with [Claude Code](https://claude.com/claude-code)