### PR TITLE
chore: add type annotations to shared inference utilities

### DIFF
--- a/src/llama_stack/providers/utils/bedrock/client.py
+++ b/src/llama_stack/providers/utils/bedrock/client.py
@@ -5,9 +5,9 @@
 # the root directory of this source tree.
 
 
-import boto3
-from botocore.client import BaseClient
-from botocore.config import Config
+import boto3  # type: ignore[import-untyped] # ty: ignore[unresolved-import]
+from botocore.client import BaseClient  # type: ignore[import-untyped] # ty: ignore[unresolved-import]
+from botocore.config import Config  # type: ignore[import-untyped] # ty: ignore[unresolved-import]
 
 from llama_stack.providers.utils.bedrock.config import BedrockBaseConfig
 from llama_stack.providers.utils.bedrock.refreshable_boto_session import (

--- a/src/llama_stack/providers/utils/bedrock/config.py
+++ b/src/llama_stack/providers/utils/bedrock/config.py
@@ -5,6 +5,7 @@
 # the root directory of this source tree.
 
 import os
+from typing import Any
 
 from pydantic import Field, SecretStr
 
@@ -62,5 +63,5 @@ class BedrockBaseConfig(RemoteInferenceProviderConfig):
     )
 
     @classmethod
-    def sample_run_config(cls, **kwargs):
+    def sample_run_config(cls, **kwargs: Any) -> dict[str, Any]:
         return {}

--- a/src/llama_stack/providers/utils/bedrock/refreshable_boto_session.py
+++ b/src/llama_stack/providers/utils/bedrock/refreshable_boto_session.py
@@ -8,9 +8,9 @@ import datetime
 from time import time
 from uuid import uuid4
 
-from boto3 import Session
-from botocore.credentials import RefreshableCredentials
-from botocore.session import get_session
+from boto3 import Session  # type: ignore[import-untyped] # ty: ignore[unresolved-import]
+from botocore.credentials import RefreshableCredentials  # type: ignore[import-untyped] # ty: ignore[unresolved-import]
+from botocore.session import get_session  # type: ignore[import-untyped] # ty: ignore[unresolved-import]
 
 
 class RefreshableBotoSession:
@@ -26,11 +26,11 @@ class RefreshableBotoSession:
 
     def __init__(
         self,
-        region_name: str = None,
-        profile_name: str = None,
-        sts_arn: str = None,
-        session_name: str = None,
-        session_ttl: int = 30000,
+        region_name: str | None = None,
+        profile_name: str | None = None,
+        sts_arn: str | None = None,
+        session_name: str | None = None,
+        session_ttl: int | None = 30000,
     ):
         """
         Initialize `RefreshableBotoSession`
@@ -58,9 +58,9 @@ class RefreshableBotoSession:
         self.profile_name = profile_name
         self.sts_arn = sts_arn
         self.session_name = session_name or uuid4().hex
-        self.session_ttl = session_ttl
+        self.session_ttl = session_ttl if session_ttl is not None else 30000
 
-    def __get_session_credentials(self):
+    def __get_session_credentials(self) -> dict[str, str | None]:
         """
         Get session credentials
         """

--- a/src/llama_stack/providers/utils/common/data_schema_validator.py
+++ b/src/llama_stack/providers/utils/common/data_schema_validator.py
@@ -73,7 +73,7 @@ VALID_SCHEMAS_FOR_EVAL = [
 ]
 
 
-def get_valid_schemas(api_str: str):
+def get_valid_schemas(api_str: str) -> list[dict[str, Any]]:
     """Return the valid dataset schemas for the given API.
 
     Args:
@@ -93,7 +93,7 @@ def get_valid_schemas(api_str: str):
 def validate_dataset_schema(
     dataset_schema: dict[str, Any],
     expected_schemas: list[dict[str, Any]],
-):
+) -> None:
     """Validate that a dataset schema matches one of the expected schemas.
 
     Args:
@@ -107,7 +107,7 @@ def validate_dataset_schema(
 def validate_row_schema(
     input_row: dict[str, Any],
     expected_schemas: list[dict[str, Any]],
-):
+) -> None:
     """Validate that an input row contains keys from at least one expected schema.
 
     Args:

--- a/src/llama_stack/providers/utils/common/data_url.py
+++ b/src/llama_stack/providers/utils/common/data_url.py
@@ -7,7 +7,7 @@
 import re
 
 
-def parse_data_url(data_url: str):
+def parse_data_url(data_url: str) -> dict[str, str | bool | None]:
     """Parse a data URL into its component parts.
 
     Args:

--- a/src/llama_stack/providers/utils/inference/embedding_mixin.py
+++ b/src/llama_stack/providers/utils/inference/embedding_mixin.py
@@ -8,12 +8,12 @@ import asyncio
 import base64
 import platform
 import struct
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from llama_stack.log import get_logger
 
 if TYPE_CHECKING:
-    from sentence_transformers import SentenceTransformer
+    from sentence_transformers import SentenceTransformer  # ty: ignore[unresolved-import]
 
 from llama_stack_api import (
     ModelStore,
@@ -37,6 +37,7 @@ class SentenceTransformerEmbeddingMixin:
     """Mixin providing OpenAI-compatible embeddings via sentence-transformers models."""
 
     model_store: ModelStore
+    config: Any  # Provided by the concrete provider class via multiple inheritance
 
     async def openai_embeddings(
         self,
@@ -98,8 +99,8 @@ class SentenceTransformerEmbeddingMixin:
             log.info(f"Loading sentence transformer for {model}...")
 
             def _load_model():
-                import torch
-                from sentence_transformers import SentenceTransformer
+                import torch  # ty: ignore[unresolved-import]
+                from sentence_transformers import SentenceTransformer  # ty: ignore[unresolved-import]
 
                 platform_name = platform.system()
                 if platform_name == DARWIN:

--- a/src/llama_stack/providers/utils/inference/model_registry.py
+++ b/src/llama_stack/providers/utils/inference/model_registry.py
@@ -298,23 +298,24 @@ class ModelRegistryHelper(ModelsProtocolPrivate):
         return False
 
     async def register_model(self, model: Model) -> Model:
+        model_resource_id = model.provider_resource_id or model.model_id
         # Check if model is supported in static configuration
-        supported_model_id = self.get_provider_model_id(model.provider_resource_id)
+        supported_model_id = self.get_provider_model_id(model_resource_id)
 
         # If not found in static config, check if it's available dynamically from provider
         if not supported_model_id:
-            if await self.check_model_availability(model.provider_resource_id):
-                supported_model_id = model.provider_resource_id
+            if await self.check_model_availability(model_resource_id):
+                supported_model_id = model_resource_id
             else:
                 # note: we cannot provide a complete list of supported models without
                 #       getting a complete list from the provider, so we return "..."
                 all_supported_models = [*self.alias_to_provider_id_map.keys(), "..."]
-                raise UnsupportedModelError(model.provider_resource_id, all_supported_models)
+                raise UnsupportedModelError(model_resource_id, all_supported_models)
 
         provider_resource_id = self.get_provider_model_id(model.model_id)
         if model.model_type == ModelType.embedding:
             # embedding models are always registered by their provider model id and does not need to be mapped to a llama model
-            provider_resource_id = model.provider_resource_id
+            provider_resource_id = model_resource_id
         if provider_resource_id:
             if provider_resource_id != supported_model_id:  # be idempotent, only reject differences
                 raise ValueError(
@@ -323,7 +324,7 @@ class ModelRegistryHelper(ModelsProtocolPrivate):
         else:
             llama_model = model.metadata.get("llama_model")
             if llama_model:
-                existing_llama_model = self.get_llama_model(model.provider_resource_id)
+                existing_llama_model = self.get_llama_model(model_resource_id)
                 if existing_llama_model:
                     if existing_llama_model != llama_model:
                         raise ValueError(
@@ -331,11 +332,12 @@ class ModelRegistryHelper(ModelsProtocolPrivate):
                         )
                 else:
                     if llama_model not in ALL_HUGGINGFACE_REPOS_TO_MODEL_DESCRIPTOR:
+                        valid_keys = [k for k in ALL_HUGGINGFACE_REPOS_TO_MODEL_DESCRIPTOR if k is not None]
                         raise ValueError(
                             f"Invalid llama_model '{llama_model}' specified in metadata. "
-                            f"Must be one of: {', '.join(ALL_HUGGINGFACE_REPOS_TO_MODEL_DESCRIPTOR.keys())}"
+                            f"Must be one of: {', '.join(valid_keys)}"
                         )
-                    self.provider_id_to_llama_model_map[model.provider_resource_id] = (
+                    self.provider_id_to_llama_model_map[model_resource_id] = (
                         ALL_HUGGINGFACE_REPOS_TO_MODEL_DESCRIPTOR[llama_model]
                     )
 

--- a/src/llama_stack/providers/utils/inference/openai_compat.py
+++ b/src/llama_stack/providers/utils/inference/openai_compat.py
@@ -57,7 +57,7 @@ def convert_tooldef_to_openai_tool(
     return out
 
 
-async def prepare_openai_completion_params(**params):
+async def prepare_openai_completion_params(**params: Any) -> dict[str, Any]:
     """Prepare keyword arguments for OpenAI-compatible completion calls.
 
     Args:

--- a/src/llama_stack/providers/utils/inference/openai_mixin.py
+++ b/src/llama_stack/providers/utils/inference/openai_mixin.py
@@ -32,6 +32,7 @@ from llama_stack_api import (
     ModelType,
     OpenAIChatCompletion,
     OpenAIChatCompletionChunk,
+    OpenAIChatCompletionContentPartImageParam,
     OpenAIChatCompletionRequestWithExtraBody,
     OpenAICompletion,
     OpenAICompletionRequestWithExtraBody,
@@ -73,6 +74,12 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
     # Allow extra fields so the routing infra can inject model_store, __provider_id__, etc.
     # Allow arbitrary types for shared_ssl_context
     model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
+
+    # Runtime-injected by the routing table (core/routing_tables/common.py)
+    # model_store is typed as Any because it's a Protocol (ModelStore) which Pydantic
+    # can't validate via isinstance. The actual type is ModelStore from llama_stack_api.
+    __provider_id__: str = ""
+    model_store: Any = None
 
     config: RemoteInferenceProviderConfig
 
@@ -158,14 +165,14 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
         """
         if metadata := self.embedding_model_metadata.get(identifier):
             return Model(
-                provider_id=self.__provider_id__,  # type: ignore[attr-defined]
+                provider_id=self.__provider_id__,
                 provider_resource_id=identifier,
                 identifier=identifier,
                 model_type=ModelType.embedding,
                 metadata=metadata,
             )
         return Model(
-            provider_id=self.__provider_id__,  # type: ignore[attr-defined]
+            provider_id=self.__provider_id__,
             provider_resource_id=identifier,
             identifier=identifier,
             model_type=ModelType.llm,
@@ -290,11 +297,11 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
         :return: The provider-specific model ID (e.g., "gpt-4")
         """
         # self.model_store is injected by the distribution system at runtime
-        if not await self.model_store.has_model(model):  # type: ignore[attr-defined]
+        if not self.model_store or not await self.model_store.has_model(model):  # type: ignore[attr-defined] # has_model from routing table
             return model
 
         # Look up the registered model to get the provider-specific model ID
-        model_obj: Model = await self.model_store.get_model(model)  # type: ignore[attr-defined]
+        model_obj: Model = await self.model_store.get_model(model)
         # provider_resource_id is str | None, but we expect it to be str for OpenAI calls
         if model_obj.provider_resource_id is None:
             raise ValueError(f"Model {model} has no provider_resource_id")
@@ -379,7 +386,9 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
             async def _localize_image_url(m: OpenAIMessageParam) -> OpenAIMessageParam:
                 if isinstance(m.content, list):
                     for c in m.content:
-                        if c.type == "image_url" and c.image_url and c.image_url.url and "http" in c.image_url.url:
+                        if not isinstance(c, OpenAIChatCompletionContentPartImageParam):
+                            continue
+                        if c.image_url and c.image_url.url and "http" in c.image_url.url:
                             localize_result = await localize_image_content(c.image_url.url)
                             if localize_result is None:
                                 raise ValueError(
@@ -501,7 +510,7 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
             return model
 
         if not await self.check_model_availability(model.provider_model_id):
-            raise ValueError(f"Model {model.provider_model_id} is not available from provider {self.__provider_id__}")  # type: ignore[attr-defined]
+            raise ValueError(f"Model {model.provider_model_id} is not available from provider {self.__provider_id__}")
         return model
 
     async def unregister_model(self, model_id: str) -> None:
@@ -561,9 +570,9 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
         :return: True if the model is available dynamically or pre-registered, False otherwise.
         """
         # First check if the model is pre-registered in the model store
-        if hasattr(self, "model_store") and self.model_store:
-            qualified_model = f"{self.__provider_id__}/{model}"  # type: ignore[attr-defined]
-            if await self.model_store.has_model(qualified_model):
+        if self.model_store:
+            qualified_model = f"{self.__provider_id__}/{model}"
+            if await self.model_store.has_model(qualified_model):  # type: ignore[attr-defined] # has_model from routing table
                 return True
 
         # Then check the provider's dynamic model cache


### PR DESCRIPTION
## Summary
- Declare `model_store` (as `Any`) and `__provider_id__` (as `str`) as class attributes on `OpenAIMixin`, removing stale `# type: ignore[attr-defined]` comments
- Fix `RefreshableBotoSession.__init__` parameter types to accept `str | None` and `int | None` matching `BedrockBaseConfig` field types
- Add return type annotations to `prepare_openai_completion_params`, `get_valid_schemas`, `validate_dataset_schema`, `validate_row_schema`, `parse_data_url`, and `sample_run_config`
- Add `# ty: ignore[unresolved-import]` for untyped third-party imports (boto3, botocore, sentence_transformers, torch)
- Narrow union type handling in `_localize_image_url` using `isinstance` check for `OpenAIChatCompletionContentPartImageParam`
- Fix `model_registry.py` to handle `provider_resource_id: str | None` safely with fallback to `model_id`
- Add `config: Any` declaration to `SentenceTransformerEmbeddingMixin` for mixin compatibility

## Verification
- `ty check` on all 11 target files: **zero errors**
- `uv run pytest tests/unit/`: **1592 passed, 3 skipped** (all pre-existing skips; excluded tests have pre-existing import errors unrelated to this change)

## Test plan
- [x] `ty check` passes with zero errors on all scoped files
- [x] Unit tests pass with no regressions
- [x] No new bare `# type: ignore` without error codes
- [x] Runtime behavior unchanged (annotation-only changes + null-safe guards)

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)