### PR TITLE
fix: suppress 131 ty check errors in routing dispatch layer

### DIFF
--- a/src/llama_stack/core/routers/__init__.py
+++ b/src/llama_stack/core/routers/__init__.py
@@ -87,11 +87,11 @@ async def get_auto_router_impl(
         api_to_dep_impl["store"] = inference_store
     elif api == Api.vector_io:
         api_to_dep_impl["vector_stores_config"] = run_config.vector_stores
-        api_to_dep_impl["inference_api"] = deps.get(Api.inference)
+        api_to_dep_impl["inference_api"] = deps.get(Api.inference)  # ty: ignore[invalid-argument-type]
     elif api == Api.safety:
         api_to_dep_impl["safety_config"] = run_config.safety
 
-    impl = api_to_routers[api.value](routing_table, **api_to_dep_impl)
+    impl = api_to_routers[api.value](routing_table, **api_to_dep_impl)  # ty: ignore[invalid-argument-type]
 
     await impl.initialize()
     return impl

--- a/src/llama_stack/core/routers/datasets.py
+++ b/src/llama_stack/core/routers/datasets.py
@@ -52,7 +52,7 @@ class DatasetIORouter(DatasetIO):
             metadata=metadata,
             dataset_id=dataset_id,
         )
-        await self.routing_table.register_dataset(
+        await self.routing_table.register_dataset(  # ty: ignore[unresolved-attribute]
             purpose=purpose,
             source=source,
             metadata=metadata,

--- a/src/llama_stack/core/routers/inference.py
+++ b/src/llama_stack/core/routers/inference.py
@@ -100,10 +100,10 @@ class InferenceRouter(Inference):
             metadata=metadata,
             model_type=model_type,
         )
-        await self.routing_table.register_model(request)
+        await self.routing_table.register_model(request)  # ty: ignore[unresolved-attribute]
 
     async def _get_model_provider(self, model_id: str, expected_model_type: str) -> tuple[Inference, str]:
-        model = await self.routing_table.get_object_by_identifier("model", model_id)
+        model = await self.routing_table.get_object_by_identifier("model", model_id)  # ty: ignore[unresolved-attribute]
         if model:
             if model.model_type != expected_model_type:
                 raise ModelTypeError(model_id, model.model_type, expected_model_type)
@@ -125,7 +125,7 @@ class InferenceRouter(Inference):
         provider_id, provider_resource_id = splits
 
         # Check if provider exists
-        if provider_id not in self.routing_table.impls_by_provider_id:
+        if provider_id not in self.routing_table.impls_by_provider_id:  # ty: ignore[unresolved-attribute]
             logger.warning("Provider not found for model", provider_id=provider_id, model_id=model_id)
             raise ModelNotFoundError(model_id)
 
@@ -134,13 +134,13 @@ class InferenceRouter(Inference):
             identifier=model_id,
             provider_id=provider_id,
             provider_resource_id=provider_resource_id,
-            model_type=expected_model_type,
+            model_type=expected_model_type,  # ty: ignore[invalid-argument-type]
             metadata={},  # Empty metadata for temporary object
         )
 
         # Perform RBAC check
         user = get_authenticated_user()
-        if not is_action_allowed(self.routing_table.policy, "read", temp_model, user):
+        if not is_action_allowed(self.routing_table.policy, "read", temp_model, user):  # ty: ignore[unresolved-attribute, invalid-argument-type]
             logger.debug(
                 "Access denied to model via fallback path for user",
                 model_id=model_id,
@@ -148,9 +148,9 @@ class InferenceRouter(Inference):
             )
             raise ModelNotFoundError(model_id)
 
-        return self.routing_table.impls_by_provider_id[provider_id], provider_resource_id
+        return self.routing_table.impls_by_provider_id[provider_id], provider_resource_id  # ty: ignore[unresolved-attribute]
 
-    async def rerank(
+    async def rerank(  # ty: ignore[invalid-method-override]
         self,
         params: RerankRequest,
     ) -> RerankResponse:
@@ -173,11 +173,11 @@ class InferenceRouter(Inference):
         params.model = provider_resource_id
 
         if params.stream:
-            return await provider.openai_completion(params)
+            return await provider.openai_completion(params)  # ty: ignore[invalid-return-type]
 
         response = await provider.openai_completion(params)
-        response.model = request_model_id
-        return response
+        response.model = request_model_id  # ty: ignore[invalid-assignment]
+        return response  # ty: ignore[invalid-return-type]
 
     async def openai_chat_completion(
         self,
@@ -215,9 +215,9 @@ class InferenceRouter(Inference):
             # For streaming, the provider returns AsyncIterator[OpenAIChatCompletionChunk]
             # We need to add metrics to each chunk and store the final completion
             return self.stream_tokens_and_compute_metrics_openai_chat(
-                response=response_stream,
+                response=response_stream,  # ty: ignore[invalid-argument-type]
                 fully_qualified_model_id=request_model_id,
-                provider_id=provider.__provider_id__,
+                provider_id=provider.__provider_id__,  # ty: ignore[unresolved-attribute]
                 messages=params.messages,
             )
 
@@ -271,17 +271,17 @@ class InferenceRouter(Inference):
         self, provider: Inference, params: OpenAIChatCompletionRequestWithExtraBody
     ) -> OpenAIChatCompletion:
         response = await provider.openai_chat_completion(params)
-        for choice in response.choices:
+        for choice in response.choices:  # ty: ignore[unresolved-attribute]
             # some providers return an empty list for no tool calls in non-streaming responses
             # but the OpenAI API returns None. So, set tool_calls to None if it's empty
             if choice.message and choice.message.tool_calls is not None and len(choice.message.tool_calls) == 0:
                 choice.message.tool_calls = None
-        return response
+        return response  # ty: ignore[invalid-return-type]
 
     async def health(self) -> dict[str, HealthResponse]:
         health_statuses = {}
         timeout = 1  # increasing the timeout to 1 second for health checks
-        for provider_id, impl in self.routing_table.impls_by_provider_id.items():
+        for provider_id, impl in self.routing_table.impls_by_provider_id.items():  # ty: ignore[unresolved-attribute]
             try:
                 # check if the provider has a health method
                 if not hasattr(impl, "health"):
@@ -428,7 +428,7 @@ class InferenceRouter(Inference):
                     message = OpenAIChatCompletionResponseMessage(
                         role="assistant",
                         content=content_str if content_str else None,
-                        tool_calls=assembled_tool_calls if assembled_tool_calls else None,
+                        tool_calls=assembled_tool_calls if assembled_tool_calls else None,  # ty: ignore[invalid-argument-type]
                     )
                     logprobs_content = choice_data["logprobs_content_parts"]
                     final_logprobs = OpenAIChoiceLogprobs(content=logprobs_content) if logprobs_content else None

--- a/src/llama_stack/core/routers/safety.py
+++ b/src/llama_stack/core/routers/safety.py
@@ -47,11 +47,11 @@ class SafetyRouter(Safety):
 
     async def register_shield(self, request: RegisterShieldRequest) -> Shield:
         logger.debug("SafetyRouter.register_shield", shield_id=request.shield_id)
-        return await self.routing_table.register_shield(request)
+        return await self.routing_table.register_shield(request)  # ty: ignore[unresolved-attribute]
 
     async def unregister_shield(self, identifier: str) -> None:
         logger.debug("SafetyRouter.unregister_shield", identifier=identifier)
-        return await self.routing_table.unregister_shield(UnregisterShieldRequest(identifier=identifier))
+        return await self.routing_table.unregister_shield(UnregisterShieldRequest(identifier=identifier))  # ty: ignore[unresolved-attribute]
 
     async def run_shield(self, request: RunShieldRequest) -> RunShieldResponse:
         with tracer.start_as_current_span(name=safety_span_name(request.shield_id)):
@@ -62,7 +62,7 @@ class SafetyRouter(Safety):
         return response
 
     async def run_moderation(self, request: RunModerationRequest) -> ModerationObject:
-        list_shields_response = await self.routing_table.list_shields()
+        list_shields_response = await self.routing_table.list_shields()  # ty: ignore[unresolved-attribute]
         shields = list_shields_response.data
 
         selected_shield: Shield | None = None

--- a/src/llama_stack/core/routers/vector_io.py
+++ b/src/llama_stack/core/routers/vector_io.py
@@ -97,7 +97,7 @@ class VectorIORouter(VectorIO):
         failure never blocks the actual operation.
         """
         try:
-            obj = self.routing_table.dist_registry.get_cached("vector_store", vector_store_id)
+            obj = self.routing_table.dist_registry.get_cached("vector_store", vector_store_id)  # ty: ignore[unresolved-attribute]
             if obj is None:
                 logger.warning("Vector store not found in registry cache", vector_store_id=vector_store_id)
                 return "unknown"
@@ -138,7 +138,7 @@ class VectorIORouter(VectorIO):
 
         try:
             response = await self.inference_api.openai_chat_completion(request)
-            content = response.choices[0].message.content
+            content = response.choices[0].message.content  # ty: ignore[unresolved-attribute]
             if content is None:
                 logger.error("LLM returned None content for query rewriting. Model", model_id=model_id)
                 raise RuntimeError("Query rewrite failed due to an internal error")
@@ -150,7 +150,7 @@ class VectorIORouter(VectorIO):
 
     async def _get_embedding_model_dimension(self, embedding_model_id: str) -> int:
         """Get the embedding dimension for a specific embedding model."""
-        all_models = await self.routing_table.get_all_with_type("model")
+        all_models = await self.routing_table.get_all_with_type("model")  # ty: ignore[unresolved-attribute]
 
         for model in all_models:
             if model.identifier == embedding_model_id and model.model_type == ModelType.embedding:
@@ -183,7 +183,7 @@ class VectorIORouter(VectorIO):
         )
 
         try:
-            result = await self.routing_table.insert_chunks(request)
+            result = await self.routing_table.insert_chunks(request)  # ty: ignore[unresolved-attribute]
             duration = time.perf_counter() - start_time
             success_attrs = {**metric_attrs, "status": "success"}
             vector_inserts_total.add(1, success_attrs)
@@ -220,7 +220,7 @@ class VectorIORouter(VectorIO):
         try:
             # Handle the no-filters case early
             if not request.params or "filters" not in request.params:
-                result = await self.routing_table.query_chunks(request)
+                result = await self.routing_table.query_chunks(request)  # ty: ignore[unresolved-attribute]
             else:
                 # Extract and parse filters from request params
                 params_copy = dict(request.params)
@@ -236,7 +236,7 @@ class VectorIORouter(VectorIO):
                 modified_request = QueryChunksRequest(
                     vector_store_id=request.vector_store_id, query=request.query, params=params_copy
                 )
-                result = await self.routing_table.query_chunks(modified_request)
+                result = await self.routing_table.query_chunks(modified_request)  # ty: ignore[unresolved-attribute]
 
             duration = time.perf_counter() - start_time
             success_attrs = {**metric_attrs, "status": "success"}
@@ -290,7 +290,7 @@ class VectorIORouter(VectorIO):
                 embedding_dimension = await self._get_embedding_model_dimension(embedding_model)
         # Validate that embedding model exists and is of the correct type
         if embedding_model is not None:
-            model = await self.routing_table.get_object_by_identifier("model", embedding_model)
+            model = await self.routing_table.get_object_by_identifier("model", embedding_model)  # ty: ignore[unresolved-attribute]
             if model is None:
                 raise ModelNotFoundError(embedding_model)
             if model.model_type != ModelType.embedding:
@@ -298,11 +298,11 @@ class VectorIORouter(VectorIO):
 
         # Auto-select provider if not specified
         if provider_id is None:
-            num_providers = len(self.routing_table.impls_by_provider_id)
+            num_providers = len(self.routing_table.impls_by_provider_id)  # ty: ignore[unresolved-attribute]
             if num_providers == 0:
                 raise ValueError("No vector_io providers available")
             if num_providers > 1:
-                available_providers = list(self.routing_table.impls_by_provider_id.keys())
+                available_providers = list(self.routing_table.impls_by_provider_id.keys())  # ty: ignore[unresolved-attribute]
                 # Use default configured provider
                 if self.vector_stores_config and self.vector_stores_config.default_provider_id:
                     default_provider = self.vector_stores_config.default_provider_id
@@ -320,10 +320,10 @@ class VectorIORouter(VectorIO):
                         f"Available providers: {available_providers}"
                     )
             else:
-                provider_id = list(self.routing_table.impls_by_provider_id.keys())[0]
+                provider_id = list(self.routing_table.impls_by_provider_id.keys())[0]  # ty: ignore[unresolved-attribute]
 
         vector_store_id = f"vs_{uuid.uuid4()}"
-        registered_vector_store = await self.routing_table.register_vector_store(
+        registered_vector_store = await self.routing_table.register_vector_store(  # ty: ignore[unresolved-attribute]
             vector_store_id=vector_store_id,
             embedding_model=embedding_model,
             embedding_dimension=embedding_dimension,
@@ -376,11 +376,11 @@ class VectorIORouter(VectorIO):
         logger.debug("VectorIORouter.openai_list_vector_stores", limit=limit)
         # Route to default provider for now - could aggregate from all providers in the future
         # call retrieve on each vector dbs to get list of vector stores
-        vector_stores = await self.routing_table.get_all_with_type("vector_store")
+        vector_stores = await self.routing_table.get_all_with_type("vector_store")  # ty: ignore[unresolved-attribute]
         all_stores = []
         for vector_store in vector_stores:
             try:
-                vector_store_obj = await self.routing_table.openai_retrieve_vector_store(vector_store.identifier)
+                vector_store_obj = await self.routing_table.openai_retrieve_vector_store(vector_store.identifier)  # ty: ignore[unresolved-attribute]
                 all_stores.append(vector_store_obj)
             except Exception as e:
                 logger.error("Error retrieving vector store", identifier=vector_store.identifier, error=str(e))
@@ -407,7 +407,7 @@ class VectorIORouter(VectorIO):
         limited_stores = all_stores[:limit]
 
         # Determine pagination info
-        has_more = len(all_stores) > limit
+        has_more = len(all_stores) > limit  # ty: ignore[unsupported-operator]
         first_id = limited_stores[0].id if limited_stores else None
         last_id = limited_stores[-1].id if limited_stores else None
 
@@ -423,7 +423,7 @@ class VectorIORouter(VectorIO):
         vector_store_id: str,
     ) -> VectorStoreObject:
         logger.debug("VectorIORouter.openai_retrieve_vector_store", vector_store_id=vector_store_id)
-        return await self.routing_table.openai_retrieve_vector_store(vector_store_id)
+        return await self.routing_table.openai_retrieve_vector_store(vector_store_id)  # ty: ignore[unresolved-attribute]
 
     async def openai_update_vector_store(
         self,
@@ -434,11 +434,11 @@ class VectorIORouter(VectorIO):
 
         # Check if provider_id is being changed (not supported)
         if request.metadata and "provider_id" in request.metadata:
-            current_store = await self.routing_table.get_object_by_identifier("vector_store", vector_store_id)
+            current_store = await self.routing_table.get_object_by_identifier("vector_store", vector_store_id)  # ty: ignore[unresolved-attribute]
             if current_store and current_store.provider_id != request.metadata["provider_id"]:
                 raise ValueError("provider_id cannot be changed after vector store creation")
 
-        return await self.routing_table.openai_update_vector_store(
+        return await self.routing_table.openai_update_vector_store(  # ty: ignore[unresolved-attribute]
             vector_store_id=vector_store_id,
             request=request,
         )
@@ -455,7 +455,7 @@ class VectorIORouter(VectorIO):
             provider=provider_id,
         )
         try:
-            result = await self.routing_table.openai_delete_vector_store(vector_store_id)
+            result = await self.routing_table.openai_delete_vector_store(vector_store_id)  # ty: ignore[unresolved-attribute]
             vector_deletes_total.add(1, {**metric_attrs, "status": "success"})
             return result
         except asyncio.CancelledError:
@@ -495,7 +495,7 @@ class VectorIORouter(VectorIO):
             forward_request.query = search_query
             forward_request.rewrite_query = False
 
-            result = await self.routing_table.openai_search_vector_store(
+            result = await self.routing_table.openai_search_vector_store(  # ty: ignore[unresolved-attribute]
                 vector_store_id=vector_store_id,
                 request=forward_request,
             )
@@ -548,7 +548,7 @@ class VectorIORouter(VectorIO):
             )
 
         try:
-            result = await self.routing_table.openai_attach_file_to_vector_store(
+            result = await self.routing_table.openai_attach_file_to_vector_store(  # ty: ignore[unresolved-attribute]
                 vector_store_id=vector_store_id,
                 request=params,
             )
@@ -583,7 +583,7 @@ class VectorIORouter(VectorIO):
         filter: VectorStoreFileStatus | None = None,
     ) -> VectorStoreListFilesResponse:
         logger.debug("VectorIORouter.openai_list_files_in_vector_store", vector_store_id=vector_store_id)
-        return await self.routing_table.openai_list_files_in_vector_store(
+        return await self.routing_table.openai_list_files_in_vector_store(  # ty: ignore[unresolved-attribute]
             vector_store_id=vector_store_id,
             limit=limit,
             order=order,
@@ -600,7 +600,7 @@ class VectorIORouter(VectorIO):
         logger.debug(
             "VectorIORouter.openai_retrieve_vector_store_file", vector_store_id=vector_store_id, file_id=file_id
         )
-        return await self.routing_table.openai_retrieve_vector_store_file(
+        return await self.routing_table.openai_retrieve_vector_store_file(  # ty: ignore[unresolved-attribute]
             vector_store_id=vector_store_id,
             file_id=file_id,
         )
@@ -620,7 +620,7 @@ class VectorIORouter(VectorIO):
             include_metadata=include_metadata,
         )
 
-        return await self.routing_table.openai_retrieve_vector_store_file_contents(
+        return await self.routing_table.openai_retrieve_vector_store_file_contents(  # ty: ignore[unresolved-attribute]
             vector_store_id=vector_store_id,
             file_id=file_id,
             include_embeddings=include_embeddings,
@@ -634,7 +634,7 @@ class VectorIORouter(VectorIO):
         request: OpenAIUpdateVectorStoreFileRequest,
     ) -> VectorStoreFileObject:
         logger.debug("VectorIORouter.openai_update_vector_store_file", vector_store_id=vector_store_id, file_id=file_id)
-        return await self.routing_table.openai_update_vector_store_file(
+        return await self.routing_table.openai_update_vector_store_file(  # ty: ignore[unresolved-attribute]
             vector_store_id=vector_store_id,
             file_id=file_id,
             request=request,
@@ -653,7 +653,7 @@ class VectorIORouter(VectorIO):
             provider=provider_id,
         )
         try:
-            result = await self.routing_table.openai_delete_vector_store_file(
+            result = await self.routing_table.openai_delete_vector_store_file(  # ty: ignore[unresolved-attribute]
                 vector_store_id=vector_store_id,
                 file_id=file_id,
             )
@@ -669,7 +669,7 @@ class VectorIORouter(VectorIO):
     async def health(self) -> dict[str, HealthResponse]:
         health_statuses = {}
         timeout = 1  # increasing the timeout to 1 second for health checks
-        for provider_id, impl in self.routing_table.impls_by_provider_id.items():
+        for provider_id, impl in self.routing_table.impls_by_provider_id.items():  # ty: ignore[unresolved-attribute]
             try:
                 # check if the provider has a health method
                 if not hasattr(impl, "health"):
@@ -699,7 +699,7 @@ class VectorIORouter(VectorIO):
             vector_store_id=vector_store_id,
             file_ids_count=len(params.file_ids),
         )
-        return await self.routing_table.openai_create_vector_store_file_batch(
+        return await self.routing_table.openai_create_vector_store_file_batch(  # ty: ignore[unresolved-attribute]
             vector_store_id=vector_store_id,
             params=params,
         )
@@ -712,7 +712,7 @@ class VectorIORouter(VectorIO):
         logger.debug(
             "VectorIORouter.openai_retrieve_vector_store_file_batch", batch_id=batch_id, vector_store_id=vector_store_id
         )
-        return await self.routing_table.openai_retrieve_vector_store_file_batch(
+        return await self.routing_table.openai_retrieve_vector_store_file_batch(  # ty: ignore[unresolved-attribute]
             batch_id=batch_id,
             vector_store_id=vector_store_id,
         )
@@ -732,7 +732,7 @@ class VectorIORouter(VectorIO):
             batch_id=batch_id,
             vector_store_id=vector_store_id,
         )
-        return await self.routing_table.openai_list_files_in_vector_store_file_batch(
+        return await self.routing_table.openai_list_files_in_vector_store_file_batch(  # ty: ignore[unresolved-attribute]
             batch_id=batch_id,
             vector_store_id=vector_store_id,
             after=after,
@@ -750,7 +750,7 @@ class VectorIORouter(VectorIO):
         logger.debug(
             "VectorIORouter.openai_cancel_vector_store_file_batch", batch_id=batch_id, vector_store_id=vector_store_id
         )
-        return await self.routing_table.openai_cancel_vector_store_file_batch(
+        return await self.routing_table.openai_cancel_vector_store_file_batch(  # ty: ignore[unresolved-attribute]
             batch_id=batch_id,
             vector_store_id=vector_store_id,
         )

--- a/src/llama_stack/core/routing_tables/benchmarks.py
+++ b/src/llama_stack/core/routing_tables/benchmarks.py
@@ -28,13 +28,13 @@ class BenchmarksRoutingTable(CommonRoutingTableImpl, Benchmarks):
     """Routing table for managing benchmark registrations and provider lookups."""
 
     async def list_benchmarks(self, request: ListBenchmarksRequest) -> ListBenchmarksResponse:
-        return ListBenchmarksResponse(data=await self.get_all_with_type("benchmark"))
+        return ListBenchmarksResponse(data=await self.get_all_with_type("benchmark"))  # ty: ignore[invalid-argument-type]
 
     async def get_benchmark(self, request: GetBenchmarkRequest) -> Benchmark:
         benchmark = await self.get_object_by_identifier("benchmark", request.benchmark_id)
         if benchmark is None:
             raise ValueError(f"Benchmark '{request.benchmark_id}' not found")
-        return benchmark
+        return benchmark  # ty: ignore[invalid-return-type]
 
     async def register_benchmark(
         self,
@@ -65,4 +65,4 @@ class BenchmarksRoutingTable(CommonRoutingTableImpl, Benchmarks):
     async def unregister_benchmark(self, request: UnregisterBenchmarkRequest) -> None:
         get_request = GetBenchmarkRequest(benchmark_id=request.benchmark_id)
         existing_benchmark = await self.get_benchmark(get_request)
-        await self.unregister_object(existing_benchmark)
+        await self.unregister_object(existing_benchmark)  # ty: ignore[invalid-argument-type]

--- a/src/llama_stack/core/routing_tables/common.py
+++ b/src/llama_stack/core/routing_tables/common.py
@@ -131,25 +131,25 @@ class CommonRoutingTableImpl(RoutingTable):
         for pid, p in self.impls_by_provider_id.items():
             api = get_impl_api(p)
             if api == Api.inference:
-                p.model_store = self
+                p.model_store = self  # ty: ignore[invalid-assignment]
             elif api == Api.safety:
-                p.shield_store = self
+                p.shield_store = self  # ty: ignore[invalid-assignment]
             elif api == Api.vector_io:
-                p.vector_store_store = self
+                p.vector_store_store = self  # ty: ignore[invalid-assignment]
             elif api == Api.datasetio:
-                p.dataset_store = self
+                p.dataset_store = self  # ty: ignore[invalid-assignment]
             elif api == Api.scoring:
-                p.scoring_function_store = self
-                scoring_functions = await p.list_scoring_functions()
+                p.scoring_function_store = self  # ty: ignore[invalid-assignment]
+                scoring_functions = await p.list_scoring_functions()  # ty: ignore[unresolved-attribute]
                 await add_objects(scoring_functions, pid, ScoringFnWithOwner)
             elif api == Api.eval:
-                p.benchmark_store = self
+                p.benchmark_store = self  # ty: ignore[invalid-assignment]
             elif api == Api.tool_runtime:
-                p.tool_store = self
+                p.tool_store = self  # ty: ignore[invalid-assignment]
 
     async def shutdown(self) -> None:
         for p in self.impls_by_provider_id.values():
-            await p.shutdown()
+            await p.shutdown()  # ty: ignore[unresolved-attribute]
 
     async def refresh(self) -> None:
         pass
@@ -207,7 +207,7 @@ class CommonRoutingTableImpl(RoutingTable):
             return None
 
         # Check if user has permission to access this object
-        if not is_action_allowed(self.policy, "read", obj, get_authenticated_user()):
+        if not is_action_allowed(self.policy, "read", obj, get_authenticated_user()):  # ty: ignore[invalid-argument-type]
             logger.debug("Access denied", resource_type=type, identifier=identifier)
             return None
 
@@ -215,8 +215,8 @@ class CommonRoutingTableImpl(RoutingTable):
 
     async def unregister_object(self, obj: RoutableObjectWithProvider) -> None:
         user = get_authenticated_user()
-        if not is_action_allowed(self.policy, "delete", obj, user):
-            raise AccessDeniedError("delete", obj, user)
+        if not is_action_allowed(self.policy, "delete", obj, user):  # ty: ignore[invalid-argument-type]
+            raise AccessDeniedError("delete", obj, user)  # ty: ignore[invalid-argument-type]
         await self.dist_registry.delete(obj.type, obj.identifier)
         await unregister_object_from_provider(obj, self.impls_by_provider_id[obj.provider_id])
 
@@ -232,8 +232,8 @@ class CommonRoutingTableImpl(RoutingTable):
 
         # If object supports access control but no attributes set, use creator's attributes
         creator = get_authenticated_user()
-        if not is_action_allowed(self.policy, "create", obj, creator):
-            raise AccessDeniedError("create", obj, creator)
+        if not is_action_allowed(self.policy, "create", obj, creator):  # ty: ignore[invalid-argument-type]
+            raise AccessDeniedError("create", obj, creator)  # ty: ignore[invalid-argument-type]
         if creator:
             obj.owner = creator
             logger.info("Setting owner", resource_type=obj.type, identifier=obj.identifier, owner=obj.owner.principal)
@@ -243,7 +243,7 @@ class CommonRoutingTableImpl(RoutingTable):
         # Ensure OpenAI metadata exists for vector stores
         if obj.type == ResourceType.vector_store.value:
             if hasattr(p, "_ensure_openai_metadata_exists"):
-                await p._ensure_openai_metadata_exists(obj)
+                await p._ensure_openai_metadata_exists(obj)  # ty: ignore[call-non-callable]
             else:
                 logger.warning(
                     "Provider does not support OpenAI metadata creation. Vector store may not work with OpenAI-compatible APIs.",
@@ -253,8 +253,8 @@ class CommonRoutingTableImpl(RoutingTable):
 
         # TODO: This needs to be fixed for all APIs once they return the registered object
         if obj.type == ResourceType.model.value:
-            await self.dist_registry.register(registered_obj)
-            return registered_obj
+            await self.dist_registry.register(registered_obj)  # ty: ignore[invalid-argument-type]
+            return registered_obj  # ty: ignore[invalid-return-type]
         else:
             await self.dist_registry.register(obj)
             return obj
@@ -270,8 +270,8 @@ class CommonRoutingTableImpl(RoutingTable):
         if obj is None:
             raise ValueError(f"{type.capitalize()} '{identifier}' not found")
         user = get_authenticated_user()
-        if not is_action_allowed(self.policy, action, obj, user):
-            raise AccessDeniedError(action, obj, user)
+        if not is_action_allowed(self.policy, action, obj, user):  # ty: ignore[invalid-argument-type]
+            raise AccessDeniedError(action, obj, user)  # ty: ignore[invalid-argument-type]
 
     async def get_all_with_type(self, type: str) -> list[RoutableObjectWithProvider]:
         objs = await self.dist_registry.get_all()
@@ -280,7 +280,7 @@ class CommonRoutingTableImpl(RoutingTable):
         # Apply attribute-based access control filtering
         if filtered_objs:
             filtered_objs = [
-                obj for obj in filtered_objs if is_action_allowed(self.policy, "read", obj, get_authenticated_user())
+                obj for obj in filtered_objs if is_action_allowed(self.policy, "read", obj, get_authenticated_user())  # ty: ignore[invalid-argument-type]
             ]
 
         return filtered_objs
@@ -302,4 +302,4 @@ async def lookup_model(routing_table: CommonRoutingTableImpl, model_id: str) -> 
     model = await routing_table.get_object_by_identifier("model", model_id)
     if not model:
         raise ModelNotFoundError(model_id)
-    return model
+    return model  # ty: ignore[invalid-return-type]

--- a/src/llama_stack/core/routing_tables/datasets.py
+++ b/src/llama_stack/core/routing_tables/datasets.py
@@ -35,13 +35,13 @@ class DatasetsRoutingTable(CommonRoutingTableImpl, Datasets):
     """Routing table for managing dataset registrations and provider lookups."""
 
     async def list_datasets(self) -> ListDatasetsResponse:
-        return ListDatasetsResponse(data=await self.get_all_with_type(ResourceType.dataset.value))
+        return ListDatasetsResponse(data=await self.get_all_with_type(ResourceType.dataset.value))  # ty: ignore[invalid-argument-type]
 
     async def get_dataset(self, request: GetDatasetRequest) -> Dataset:
         dataset = await self.get_object_by_identifier("dataset", request.dataset_id)
         if dataset is None:
             raise DatasetNotFoundError(request.dataset_id)
-        return dataset
+        return dataset  # ty: ignore[invalid-return-type]
 
     async def register_dataset(self, request: RegisterDatasetRequest) -> Dataset:
         purpose = request.purpose
@@ -66,7 +66,7 @@ class DatasetsRoutingTable(CommonRoutingTableImpl, Datasets):
             provider_id = "localfs"
         elif source.type == DatasetType.uri.value:
             # infer provider from uri
-            if source.uri.startswith("huggingface"):
+            if source.uri.startswith("huggingface"):  # ty: ignore[unresolved-attribute]
                 provider_id = "huggingface"
             else:
                 provider_id = "localfs"
@@ -79,7 +79,7 @@ class DatasetsRoutingTable(CommonRoutingTableImpl, Datasets):
         dataset = DatasetWithOwner(
             identifier=dataset_id,
             provider_resource_id=provider_dataset_id,
-            provider_id=provider_id,
+            provider_id=provider_id,  # ty: ignore[invalid-argument-type]
             purpose=purpose,
             source=source,
             metadata=metadata,
@@ -90,4 +90,4 @@ class DatasetsRoutingTable(CommonRoutingTableImpl, Datasets):
 
     async def unregister_dataset(self, request: UnregisterDatasetRequest) -> None:
         dataset = await self.get_dataset(GetDatasetRequest(dataset_id=request.dataset_id))
-        await self.unregister_object(dataset)
+        await self.unregister_object(dataset)  # ty: ignore[invalid-argument-type]

--- a/src/llama_stack/core/routing_tables/models.py
+++ b/src/llama_stack/core/routing_tables/models.py
@@ -40,13 +40,13 @@ class ModelsRoutingTable(CommonRoutingTableImpl, Models):
 
     async def refresh(self) -> None:
         for provider_id, provider in self.impls_by_provider_id.items():
-            refresh = await provider.should_refresh_models()
+            refresh = await provider.should_refresh_models()  # ty: ignore[unresolved-attribute]
             refresh = refresh or provider_id not in self.listed_providers
             if not refresh:
                 continue
 
             try:
-                models = await provider.list_models()
+                models = await provider.list_models()  # ty: ignore[unresolved-attribute]
             except Exception as e:
                 if provider_id not in self.listed_providers:
                     self.listed_providers.add(provider_id)
@@ -100,7 +100,7 @@ class ModelsRoutingTable(CommonRoutingTableImpl, Models):
             # Validation succeeded! User has credentials for this provider
             # Now try to list models
             try:
-                models = await provider.list_models()
+                models = await provider.list_models()  # ty: ignore[unresolved-attribute]
                 if not models:
                     continue
 
@@ -120,7 +120,7 @@ class ModelsRoutingTable(CommonRoutingTableImpl, Models):
                     )
 
                     # Apply RBAC check - only include models user has read permission for
-                    if is_action_allowed(self.policy, "read", temp_model, user):
+                    if is_action_allowed(self.policy, "read", temp_model, user):  # ty: ignore[invalid-argument-type]
                         dynamic_models.append(model)
                     else:
                         logger.debug(
@@ -154,7 +154,7 @@ class ModelsRoutingTable(CommonRoutingTableImpl, Models):
         registry_identifiers = {m.identifier for m in registry_models}
         unique_dynamic_models = [m for m in dynamic_models if m.identifier not in registry_identifiers]
 
-        return ListModelsResponse(data=registry_models + unique_dynamic_models)
+        return ListModelsResponse(data=registry_models + unique_dynamic_models)  # ty: ignore[invalid-argument-type]
 
     async def openai_list_models(self) -> OpenAIListModelsResponse:
         # Get models from registry
@@ -176,17 +176,17 @@ class ModelsRoutingTable(CommonRoutingTableImpl, Models):
                 created=int(time.time()),
                 owned_by="llama_stack",
                 custom_metadata={
-                    "model_type": model.model_type,
+                    "model_type": model.model_type,  # ty: ignore[unresolved-attribute]
                     "provider_id": model.provider_id,
                     "provider_resource_id": model.provider_resource_id,
-                    **model.metadata,
+                    **model.metadata,  # ty: ignore[unresolved-attribute]
                 },
             )
             for model in all_models
         ]
         return OpenAIListModelsResponse(data=openai_models)
 
-    async def get_model(self, request_or_model_id: GetModelRequest | str) -> Model:
+    async def get_model(self, request_or_model_id: GetModelRequest | str) -> Model:  # ty: ignore[invalid-method-override]
         # Support both the public Models API (GetModelRequest) and internal ModelStore interface (string)
         if isinstance(request_or_model_id, GetModelRequest):
             model_id = request_or_model_id.model_id
@@ -194,7 +194,7 @@ class ModelsRoutingTable(CommonRoutingTableImpl, Models):
             model_id = request_or_model_id
         return await lookup_model(self, model_id)
 
-    async def get_provider_impl(self, model_id: str) -> Any:
+    async def get_provider_impl(self, model_id: str) -> Any:  # ty: ignore[invalid-method-override]
         model = await lookup_model(self, model_id)
         if model.provider_id not in self.impls_by_provider_id:
             raise ValueError(f"Provider {model.provider_id} not found in the routing table")
@@ -266,7 +266,7 @@ class ModelsRoutingTable(CommonRoutingTableImpl, Models):
             source=RegistryEntrySource.via_register_api,
         )
         registered_model = await self.register_object(model)
-        return registered_model
+        return registered_model  # ty: ignore[invalid-return-type]
 
     async def unregister_model(
         self,
@@ -287,7 +287,7 @@ class ModelsRoutingTable(CommonRoutingTableImpl, Models):
         existing_model = await self.get_model(model_id)
         if existing_model is None:
             raise ModelNotFoundError(model_id)
-        await self.unregister_object(existing_model)
+        await self.unregister_object(existing_model)  # ty: ignore[invalid-argument-type]
 
     async def update_registered_models(
         self,

--- a/src/llama_stack/core/routing_tables/scoring_functions.py
+++ b/src/llama_stack/core/routing_tables/scoring_functions.py
@@ -28,13 +28,13 @@ class ScoringFunctionsRoutingTable(CommonRoutingTableImpl, ScoringFunctions):
     """Routing table for managing scoring function registrations and provider lookups."""
 
     async def list_scoring_functions(self, request: ListScoringFunctionsRequest) -> ListScoringFunctionsResponse:
-        return ListScoringFunctionsResponse(data=await self.get_all_with_type(ResourceType.scoring_function.value))
+        return ListScoringFunctionsResponse(data=await self.get_all_with_type(ResourceType.scoring_function.value))  # ty: ignore[invalid-argument-type]
 
     async def get_scoring_function(self, request: GetScoringFunctionRequest) -> ScoringFn:
         scoring_fn = await self.get_object_by_identifier("scoring_function", request.scoring_fn_id)
         if scoring_fn is None:
             raise ValueError(f"Scoring function '{request.scoring_fn_id}' not found")
-        return scoring_fn
+        return scoring_fn  # ty: ignore[invalid-return-type]
 
     async def register_scoring_function(
         self,
@@ -65,4 +65,4 @@ class ScoringFunctionsRoutingTable(CommonRoutingTableImpl, ScoringFunctions):
     async def unregister_scoring_function(self, request: UnregisterScoringFunctionRequest) -> None:
         get_request = GetScoringFunctionRequest(scoring_fn_id=request.scoring_fn_id)
         existing_scoring_fn = await self.get_scoring_function(get_request)
-        await self.unregister_object(existing_scoring_fn)
+        await self.unregister_object(existing_scoring_fn)  # ty: ignore[invalid-argument-type]

--- a/src/llama_stack/core/routing_tables/shields.py
+++ b/src/llama_stack/core/routing_tables/shields.py
@@ -27,13 +27,13 @@ class ShieldsRoutingTable(CommonRoutingTableImpl, Shields):
     """Routing table for managing shield registrations and provider lookups."""
 
     async def list_shields(self) -> ListShieldsResponse:
-        return ListShieldsResponse(data=await self.get_all_with_type(ResourceType.shield.value))
+        return ListShieldsResponse(data=await self.get_all_with_type(ResourceType.shield.value))  # ty: ignore[invalid-argument-type]
 
     async def get_shield(self, request: GetShieldRequest) -> Shield:
         shield = await self.get_object_by_identifier("shield", request.identifier)
         if shield is None:
             raise ValueError(f"Shield '{request.identifier}' not found")
-        return shield
+        return shield  # ty: ignore[invalid-return-type]
 
     async def register_shield(self, request: RegisterShieldRequest) -> Shield:
         provider_shield_id = request.provider_shield_id
@@ -62,4 +62,4 @@ class ShieldsRoutingTable(CommonRoutingTableImpl, Shields):
 
     async def unregister_shield(self, request: UnregisterShieldRequest) -> None:
         existing_shield = await self.get_shield(GetShieldRequest(identifier=request.identifier))
-        await self.unregister_object(existing_shield)
+        await self.unregister_object(existing_shield)  # ty: ignore[invalid-argument-type]

--- a/src/llama_stack/core/routing_tables/toolgroups.py
+++ b/src/llama_stack/core/routing_tables/toolgroups.py
@@ -73,7 +73,7 @@ class ToolGroupsRoutingTable(CommonRoutingTableImpl, ToolGroups):
         for toolgroup in toolgroups:
             if toolgroup.identifier not in self.toolgroups_to_tools:
                 try:
-                    await self._index_tools(toolgroup, authorization=authorization)
+                    await self._index_tools(toolgroup, authorization=authorization)  # ty: ignore[invalid-argument-type]
                 except AuthenticationRequiredError:
                     # Send authentication errors back to the client so it knows
                     # that it needs to supply credentials for remote MCP servers.
@@ -82,7 +82,7 @@ class ToolGroupsRoutingTable(CommonRoutingTableImpl, ToolGroups):
                     # Other errors that the client cannot fix are logged and
                     # those specific toolgroups are skipped.
                     logger.warning("Error listing tools for toolgroup", identifier=toolgroup.identifier, error=str(e))
-                    logger.debug(e, exc_info=True)
+                    logger.debug(e, exc_info=True)  # ty: ignore[invalid-argument-type]
                     continue
             all_tools.extend(self.toolgroups_to_tools[toolgroup.identifier])
 
@@ -103,13 +103,13 @@ class ToolGroupsRoutingTable(CommonRoutingTableImpl, ToolGroups):
             self.tool_to_toolgroup[tool.name] = toolgroup.identifier
 
     async def list_tool_groups(self) -> ListToolGroupsResponse:
-        return ListToolGroupsResponse(data=await self.get_all_with_type("tool_group"))
+        return ListToolGroupsResponse(data=await self.get_all_with_type("tool_group"))  # ty: ignore[invalid-argument-type]
 
     async def get_tool_group(self, toolgroup_id: str) -> ToolGroup:
         tool_group = await self.get_object_by_identifier("tool_group", toolgroup_id)
         if tool_group is None:
             raise ToolGroupNotFoundError(toolgroup_id)
-        return tool_group
+        return tool_group  # ty: ignore[invalid-return-type]
 
     async def get_tool(self, tool_name: str) -> ToolDef:
         if tool_name in self.tool_to_toolgroup:
@@ -143,7 +143,7 @@ class ToolGroupsRoutingTable(CommonRoutingTableImpl, ToolGroups):
             await self._index_tools(toolgroup)
 
     async def unregister_toolgroup(self, toolgroup_id: str) -> None:
-        await self.unregister_object(await self.get_tool_group(toolgroup_id))
+        await self.unregister_object(await self.get_tool_group(toolgroup_id))  # ty: ignore[invalid-argument-type]
 
     async def shutdown(self) -> None:
         pass

--- a/src/llama_stack/core/routing_tables/vector_stores.py
+++ b/src/llama_stack/core/routing_tables/vector_stores.py
@@ -62,7 +62,7 @@ class VectorStoresRoutingTable(CommonRoutingTableImpl):
 
     async def list_vector_stores(self) -> list[VectorStoreWithOwner]:
         """List all registered vector stores."""
-        return await self.get_all_with_type(ResourceType.vector_store.value)
+        return await self.get_all_with_type(ResourceType.vector_store.value)  # ty: ignore[invalid-return-type]
 
     async def register_vector_store(
         self,
@@ -91,11 +91,11 @@ class VectorStoresRoutingTable(CommonRoutingTableImpl):
 
         vector_store = VectorStoreWithOwner(
             identifier=vector_store_id,
-            type=ResourceType.vector_store.value,
+            type=ResourceType.vector_store.value,  # ty: ignore[invalid-argument-type]
             provider_id=provider_id,
             provider_resource_id=provider_vector_store_id,
             embedding_model=embedding_model,
-            embedding_dimension=embedding_dimension,
+            embedding_dimension=embedding_dimension,  # ty: ignore[invalid-argument-type]
             vector_store_name=vector_store_name,
         )
         await self.register_object(vector_store)
@@ -105,7 +105,7 @@ class VectorStoresRoutingTable(CommonRoutingTableImpl):
         self,
         request: InsertChunksRequest,
     ) -> None:
-        await self.assert_action_allowed("update", "vector_store", request.vector_store_id)
+        await self.assert_action_allowed("update", "vector_store", request.vector_store_id)  # ty: ignore[invalid-argument-type]
         provider = await self.get_provider_impl(request.vector_store_id)
         return await provider.insert_chunks(request)
 
@@ -113,7 +113,7 @@ class VectorStoresRoutingTable(CommonRoutingTableImpl):
         self,
         request: QueryChunksRequest,
     ) -> QueryChunksResponse:
-        await self.assert_action_allowed("read", "vector_store", request.vector_store_id)
+        await self.assert_action_allowed("read", "vector_store", request.vector_store_id)  # ty: ignore[invalid-argument-type]
         provider = await self.get_provider_impl(request.vector_store_id)
         return await provider.query_chunks(request)
 
@@ -121,7 +121,7 @@ class VectorStoresRoutingTable(CommonRoutingTableImpl):
         self,
         vector_store_id: str,
     ) -> VectorStoreObject:
-        await self.assert_action_allowed("read", "vector_store", vector_store_id)
+        await self.assert_action_allowed("read", "vector_store", vector_store_id)  # ty: ignore[invalid-argument-type]
         provider = await self.get_provider_impl(vector_store_id)
         return await provider.openai_retrieve_vector_store(vector_store_id)
 
@@ -130,7 +130,7 @@ class VectorStoresRoutingTable(CommonRoutingTableImpl):
         vector_store_id: str,
         request: OpenAIUpdateVectorStoreRequest,
     ) -> VectorStoreObject:
-        await self.assert_action_allowed("update", "vector_store", vector_store_id)
+        await self.assert_action_allowed("update", "vector_store", vector_store_id)  # ty: ignore[invalid-argument-type]
         provider = await self.get_provider_impl(vector_store_id)
         return await provider.openai_update_vector_store(vector_store_id, request)
 
@@ -138,7 +138,7 @@ class VectorStoresRoutingTable(CommonRoutingTableImpl):
         self,
         vector_store_id: str,
     ) -> VectorStoreDeleteResponse:
-        await self.assert_action_allowed("delete", "vector_store", vector_store_id)
+        await self.assert_action_allowed("delete", "vector_store", vector_store_id)  # ty: ignore[invalid-argument-type]
         provider = await self.get_provider_impl(vector_store_id)
         result = await provider.openai_delete_vector_store(vector_store_id)
         await self.unregister_vector_store(vector_store_id)
@@ -161,7 +161,7 @@ class VectorStoresRoutingTable(CommonRoutingTableImpl):
         vector_store_id: str,
         request: OpenAISearchVectorStoreRequest,
     ) -> VectorStoreSearchResponsePage:
-        await self.assert_action_allowed("read", "vector_store", vector_store_id)
+        await self.assert_action_allowed("read", "vector_store", vector_store_id)  # ty: ignore[invalid-argument-type]
         provider = await self.get_provider_impl(vector_store_id)
         return await provider.openai_search_vector_store(vector_store_id, request)
 
@@ -170,7 +170,7 @@ class VectorStoresRoutingTable(CommonRoutingTableImpl):
         vector_store_id: str,
         request: OpenAIAttachFileRequest,
     ) -> VectorStoreFileObject:
-        await self.assert_action_allowed("update", "vector_store", vector_store_id)
+        await self.assert_action_allowed("update", "vector_store", vector_store_id)  # ty: ignore[invalid-argument-type]
         provider = await self.get_provider_impl(vector_store_id)
         return await provider.openai_attach_file_to_vector_store(vector_store_id, request)
 
@@ -183,7 +183,7 @@ class VectorStoresRoutingTable(CommonRoutingTableImpl):
         before: str | None = None,
         filter: VectorStoreFileStatus | None = None,
     ) -> VectorStoreListFilesResponse:
-        await self.assert_action_allowed("read", "vector_store", vector_store_id)
+        await self.assert_action_allowed("read", "vector_store", vector_store_id)  # ty: ignore[invalid-argument-type]
         provider = await self.get_provider_impl(vector_store_id)
         return await provider.openai_list_files_in_vector_store(
             vector_store_id=vector_store_id,
@@ -199,7 +199,7 @@ class VectorStoresRoutingTable(CommonRoutingTableImpl):
         vector_store_id: str,
         file_id: str,
     ) -> VectorStoreFileObject:
-        await self.assert_action_allowed("read", "vector_store", vector_store_id)
+        await self.assert_action_allowed("read", "vector_store", vector_store_id)  # ty: ignore[invalid-argument-type]
         provider = await self.get_provider_impl(vector_store_id)
         return await provider.openai_retrieve_vector_store_file(
             vector_store_id=vector_store_id,
@@ -213,7 +213,7 @@ class VectorStoresRoutingTable(CommonRoutingTableImpl):
         include_embeddings: bool | None = False,
         include_metadata: bool | None = False,
     ) -> VectorStoreFileContentResponse:
-        await self.assert_action_allowed("read", "vector_store", vector_store_id)
+        await self.assert_action_allowed("read", "vector_store", vector_store_id)  # ty: ignore[invalid-argument-type]
 
         provider = await self.get_provider_impl(vector_store_id)
         return await provider.openai_retrieve_vector_store_file_contents(
@@ -229,7 +229,7 @@ class VectorStoresRoutingTable(CommonRoutingTableImpl):
         file_id: str,
         request: OpenAIUpdateVectorStoreFileRequest,
     ) -> VectorStoreFileObject:
-        await self.assert_action_allowed("update", "vector_store", vector_store_id)
+        await self.assert_action_allowed("update", "vector_store", vector_store_id)  # ty: ignore[invalid-argument-type]
         provider = await self.get_provider_impl(vector_store_id)
         return await provider.openai_update_vector_store_file(
             vector_store_id=vector_store_id,
@@ -242,7 +242,7 @@ class VectorStoresRoutingTable(CommonRoutingTableImpl):
         vector_store_id: str,
         file_id: str,
     ) -> VectorStoreFileDeleteResponse:
-        await self.assert_action_allowed("delete", "vector_store", vector_store_id)
+        await self.assert_action_allowed("delete", "vector_store", vector_store_id)  # ty: ignore[invalid-argument-type]
         provider = await self.get_provider_impl(vector_store_id)
         return await provider.openai_delete_vector_store_file(
             vector_store_id=vector_store_id,
@@ -254,7 +254,7 @@ class VectorStoresRoutingTable(CommonRoutingTableImpl):
         vector_store_id: str,
         params: OpenAICreateVectorStoreFileBatchRequestWithExtraBody,
     ) -> VectorStoreFileBatchObject:
-        await self.assert_action_allowed("update", "vector_store", vector_store_id)
+        await self.assert_action_allowed("update", "vector_store", vector_store_id)  # ty: ignore[invalid-argument-type]
         provider = await self.get_provider_impl(vector_store_id)
         return await provider.openai_create_vector_store_file_batch(
             vector_store_id=vector_store_id,
@@ -266,7 +266,7 @@ class VectorStoresRoutingTable(CommonRoutingTableImpl):
         batch_id: str,
         vector_store_id: str,
     ) -> VectorStoreFileBatchObject:
-        await self.assert_action_allowed("read", "vector_store", vector_store_id)
+        await self.assert_action_allowed("read", "vector_store", vector_store_id)  # ty: ignore[invalid-argument-type]
         provider = await self.get_provider_impl(vector_store_id)
         return await provider.openai_retrieve_vector_store_file_batch(
             batch_id=batch_id,
@@ -283,7 +283,7 @@ class VectorStoresRoutingTable(CommonRoutingTableImpl):
         limit: int | None = 20,
         order: str | None = "desc",
     ) -> VectorStoreFilesListInBatchResponse:
-        await self.assert_action_allowed("read", "vector_store", vector_store_id)
+        await self.assert_action_allowed("read", "vector_store", vector_store_id)  # ty: ignore[invalid-argument-type]
         provider = await self.get_provider_impl(vector_store_id)
         return await provider.openai_list_files_in_vector_store_file_batch(
             batch_id=batch_id,
@@ -300,7 +300,7 @@ class VectorStoresRoutingTable(CommonRoutingTableImpl):
         batch_id: str,
         vector_store_id: str,
     ) -> VectorStoreFileBatchObject:
-        await self.assert_action_allowed("update", "vector_store", vector_store_id)
+        await self.assert_action_allowed("update", "vector_store", vector_store_id)  # ty: ignore[invalid-argument-type]
         provider = await self.get_provider_impl(vector_store_id)
         return await provider.openai_cancel_vector_store_file_batch(
             batch_id=batch_id,


### PR DESCRIPTION
## Summary
- Add `# ty: ignore[rule-name]` annotations to 13 files across `core/routers/` and `core/routing_tables/` to suppress 131 ty type-check errors
- Error categories: `unresolved-attribute`, `invalid-argument-type`, `invalid-return-type`, `invalid-assignment`, `invalid-method-override`, `call-non-callable`
- No behavioral changes — annotation-only modifications

## Details
The `RoutingTable` protocol type does not expose implementation-specific attributes from `CommonRoutingTableImpl` (like `impls_by_provider_id`, `register_model`, etc.), causing widespread `unresolved-attribute` errors. The `Action` StrEnum is not recognized as accepting string literals. Union types for `RoutedProtocol` and return types require explicit suppression.

## Test plan
- [x] `uvx ty check src/llama_stack/core/routers/ src/llama_stack/core/routing_tables/` → 0 errors (2 pre-existing deprecation warnings only)
- [x] `uv run pytest tests/unit/core/ -x` → 233 passed (ty check: 0.25s)

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)