### PR TITLE
Add type annotations to core server lifecycle

### DIFF
--- a/src/llama_stack/core/admin.py
+++ b/src/llama_stack/core/admin.py
@@ -44,7 +44,7 @@ class AdminImplConfig(BaseModel):
     config: StackConfig
 
 
-async def get_provider_impl(config, deps):
+async def get_provider_impl(config: AdminImplConfig, deps: dict[Api, Any]) -> "AdminImpl":
     """Create and initialize an AdminImpl instance.
 
     Args:
@@ -62,7 +62,7 @@ async def get_provider_impl(config, deps):
 class AdminImpl(Admin):
     """Implementation of the Admin API providing provider management, route listing, health, and version endpoints."""
 
-    def __init__(self, config: AdminImplConfig, deps):
+    def __init__(self, config: AdminImplConfig, deps: dict[Api, Any]) -> None:
         self.config = config
         self.deps = deps
 

--- a/src/llama_stack/core/client.py
+++ b/src/llama_stack/core/client.py
@@ -20,7 +20,7 @@ from llama_stack_api import RemoteProviderConfig
 _CLIENT_CLASSES = {}
 
 
-async def get_client_impl(protocol, config: RemoteProviderConfig, _deps: Any):
+async def get_client_impl(protocol: type, config: RemoteProviderConfig, _deps: Any) -> Any:
     """Create and initialize an API client for a remote provider.
 
     Args:
@@ -37,7 +37,7 @@ async def get_client_impl(protocol, config: RemoteProviderConfig, _deps: Any):
     return impl
 
 
-def create_api_client_class(protocol) -> type:
+def create_api_client_class(protocol: type) -> type:
     """Dynamically create an API client class for the given protocol.
 
     Args:
@@ -61,10 +61,10 @@ def create_api_client_class(protocol) -> type:
                     sig = inspect.signature(method)
                     self.routes[name] = (method.__webmethod__, sig)
 
-        async def initialize(self):
+        async def initialize(self) -> None:
             pass
 
-        async def shutdown(self):
+        async def shutdown(self) -> None:
             pass
 
         async def __acall__(self, method_name: str, *args, **kwargs) -> Any:
@@ -95,6 +95,7 @@ def create_api_client_class(protocol) -> type:
                 if j is None:
                     return None
                 # print(f"({protocol.__name__}) Returning {j}, type {return_type}")
+                assert return_type is not None
                 return parse_obj_as(return_type, j)
 
         async def _call_streaming(self, method_name: str, *args, **kwargs) -> Any:
@@ -194,7 +195,7 @@ def create_api_client_class(protocol) -> type:
 
             method_impl.__name__ = name
             method_impl.__qualname__ = f"APIClient.{name}"
-            method_impl.__signature__ = inspect.signature(method)
+            method_impl.__signature__ = inspect.signature(method)  # ty: ignore[unresolved-attribute]
             setattr(APIClient, name, method_impl)
 
     # Name the class after the protocol
@@ -203,7 +204,7 @@ def create_api_client_class(protocol) -> type:
     return APIClient
 
 
-def extract_non_async_iterator_type(type_hint):
+def extract_non_async_iterator_type(type_hint: Any) -> Any:
     """Extract the non-AsyncIterator type from a Union type hint.
 
     Args:
@@ -220,7 +221,7 @@ def extract_non_async_iterator_type(type_hint):
     return type_hint
 
 
-def extract_async_iterator_type(type_hint):
+def extract_async_iterator_type(type_hint: Any) -> Any:
     """Extract the inner type from an AsyncIterator within a Union type hint.
 
     Args:

--- a/src/llama_stack/core/inspect.py
+++ b/src/llama_stack/core/inspect.py
@@ -17,6 +17,8 @@ from llama_stack.core.server.fastapi_router_registry import (
     get_router_routes,
 )
 from llama_stack.core.server.routes import get_all_api_routes
+from typing import Any
+
 from llama_stack_api import (
     Api,
     HealthInfo,
@@ -34,7 +36,7 @@ class DistributionInspectConfig(BaseModel):
     config: StackConfig
 
 
-async def get_provider_impl(config, deps):
+async def get_provider_impl(config: DistributionInspectConfig, deps: dict[Api, Any]) -> "DistributionInspectImpl":
     """Create and initialize a DistributionInspectImpl instance.
 
     Args:
@@ -52,7 +54,7 @@ async def get_provider_impl(config, deps):
 class DistributionInspectImpl(Inspect):
     """Implementation of the Inspect API providing route listing, health, and version endpoints."""
 
-    def __init__(self, config: DistributionInspectConfig, deps):
+    def __init__(self, config: DistributionInspectConfig, deps: dict[Api, Any]) -> None:
         self.stack_config = config.config
         self.deps = deps
 

--- a/src/llama_stack/core/providers.py
+++ b/src/llama_stack/core/providers.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 
 from llama_stack.log import get_logger
 from llama_stack_api import (
+    Api,
     HealthResponse,
     HealthStatus,
     InspectProviderRequest,
@@ -31,7 +32,7 @@ class ProviderImplConfig(BaseModel):
     config: StackConfig
 
 
-async def get_provider_impl(config, deps):
+async def get_provider_impl(config: ProviderImplConfig, deps: dict[Api, Any]) -> "ProviderImpl":
     """Create and initialize a ProviderImpl instance.
 
     Args:
@@ -49,7 +50,7 @@ async def get_provider_impl(config, deps):
 class ProviderImpl(Providers):
     """Implementation of the Providers API for listing and inspecting configured providers."""
 
-    def __init__(self, config, deps):
+    def __init__(self, config: ProviderImplConfig, deps: dict[Api, Any]) -> None:
         self.stack_config = config.config
         self.deps = deps
 

--- a/src/llama_stack/core/stack.py
+++ b/src/llama_stack/core/stack.py
@@ -11,7 +11,7 @@ import os
 import re
 import tempfile
 from pathlib import Path
-from typing import Any, get_type_hints
+from typing import Any, cast, get_type_hints
 
 import yaml
 from pydantic import BaseModel
@@ -520,12 +520,13 @@ def replace_env_vars(config: Any, path: str = "") -> Any:
                 # Special handling for providers: first resolve the provider_id to check if provider
                 # is disabled so that we can skip config env variable expansion and avoid validation errors
                 if isinstance(v, dict) and "provider_id" in v:
+                    v_dict = cast(dict[str, Any], v)
                     try:
-                        resolved_provider_id = replace_env_vars(v["provider_id"], f"{path}[{i}].provider_id")
+                        resolved_provider_id = replace_env_vars(v_dict["provider_id"], f"{path}[{i}].provider_id")
                         if resolved_provider_id == "__disabled__":
                             logger.debug(
                                 "Skipping config env variable expansion for disabled provider",
-                                v_get_provider_id=v.get("provider_id", ""),
+                                v_get_provider_id=v_dict.get("provider_id", ""),
                             )
                             continue
                     except EnvVarError:
@@ -535,11 +536,12 @@ def replace_env_vars(config: Any, path: str = "") -> Any:
                 # Special handling for registered resources: check if ID field resolves to empty/None
                 # from conditional env vars (e.g., ${env.VAR:+value}) and skip the entry if so
                 if isinstance(v, dict):
+                    v_res = cast(dict[str, Any], v)
                     should_skip = False
                     for id_field in RESOURCE_ID_FIELDS:
-                        if id_field in v:
+                        if id_field in v_res:
                             try:
-                                resolved_id = replace_env_vars(v[id_field], f"{path}[{i}].{id_field}")
+                                resolved_id = replace_env_vars(v_res[id_field], f"{path}[{i}].{id_field}")
                                 if resolved_id is None or resolved_id == "":
                                     logger.debug(
                                         "Skipping [] with empty (conditional env var not set)",
@@ -698,7 +700,7 @@ def add_internal_implementations(impls: dict[Api, Any], config: StackConfig, pol
     impls[Api.connectors] = connectors_impl
 
 
-def _initialize_storage(run_config: StackConfig):
+def _initialize_storage(run_config: StackConfig) -> None:
     kv_backends: dict[str, StorageBackendConfig] = {}
     sql_backends: dict[str, StorageBackendConfig] = {}
     for backend_name, backend_config in run_config.storage.backends.items():
@@ -723,11 +725,11 @@ class Stack:
     def __init__(self, run_config: StackConfig, provider_registry: ProviderRegistry | None = None):
         self.run_config = run_config
         self.provider_registry = provider_registry
-        self.impls = None
+        self.impls: dict[Api, Any] | None = None
 
     # Produces a stack of providers for the given run config. Not all APIs may be
     # asked for in the run config.
-    async def initialize(self):
+    async def initialize(self) -> None:
         if "LLAMA_STACK_TEST_INFERENCE_MODE" in os.environ:
             from llama_stack.testing.api_recorder import setup_api_recording
 
@@ -741,7 +743,8 @@ class Stack:
         stores = self.run_config.storage.stores
         if not stores.metadata:
             raise ValueError("storage.stores.metadata must be configured with a kv_* backend")
-        dist_registry, _ = await create_dist_registry(stores.metadata, self.run_config.distro_name)
+        distro_name = self.run_config.distro_name or ""
+        dist_registry, _ = await create_dist_registry(stores.metadata, distro_name)
         policy = self.run_config.server.auth.access_policy if self.run_config.server.auth else []
 
         internal_impls = {}
@@ -770,7 +773,7 @@ class Stack:
         await validate_safety_config(self.run_config.safety, impls)
         self.impls = impls
 
-    def create_registry_refresh_task(self):
+    def create_registry_refresh_task(self) -> None:
         assert self.impls is not None, "Must call initialize() before starting"
 
         global REGISTRY_REFRESH_TASK
@@ -789,7 +792,9 @@ class Stack:
 
         REGISTRY_REFRESH_TASK.add_done_callback(cb)
 
-    async def shutdown(self):
+    async def shutdown(self) -> None:
+        if self.impls is None:
+            return
         for impl in self.impls.values():
             impl_name = impl.__class__.__name__
             logger.debug("Shutting down", impl_name=impl_name)

--- a/src/llama_stack/core/testing_context.py
+++ b/src/llama_stack/core/testing_context.py
@@ -5,7 +5,7 @@
 # the root directory of this source tree.
 
 import os
-from contextvars import ContextVar
+from contextvars import ContextVar, Token
 
 from llama_stack.core.request_headers import PROVIDER_DATA_VAR
 
@@ -21,7 +21,7 @@ def get_test_context() -> str | None:
     return TEST_CONTEXT.get()
 
 
-def set_test_context(value: str | None):
+def set_test_context(value: str | None) -> Token[str | None]:
     """Set the test context identifier for the current async context.
 
     Args:
@@ -33,7 +33,7 @@ def set_test_context(value: str | None):
     return TEST_CONTEXT.set(value)
 
 
-def reset_test_context(token) -> None:
+def reset_test_context(token: Token[str | None]) -> None:
     """Reset the test context to its previous value using a token from set_test_context.
 
     Args:
@@ -42,7 +42,7 @@ def reset_test_context(token) -> None:
     TEST_CONTEXT.reset(token)
 
 
-def sync_test_context_from_provider_data():
+def sync_test_context_from_provider_data() -> Token[str | None] | None:
     """Sync test context from provider data when running in server test mode."""
     if "LLAMA_STACK_TEST_INFERENCE_MODE" not in os.environ:
         return None

--- a/src/llama_stack/core/utils/context.py
+++ b/src/llama_stack/core/utils/context.py
@@ -5,7 +5,9 @@
 # the root directory of this source tree.
 
 from collections.abc import AsyncGenerator
-from contextvars import ContextVar
+from contextvars import ContextVar, Token
+
+from typing import Any
 
 _MISSING = object()
 
@@ -23,8 +25,8 @@ def preserve_contexts_async_generator[T](
 
     async def wrapper() -> AsyncGenerator[T, None]:
         while True:
-            previous_values: dict[ContextVar, object] = {}
-            tokens: dict[ContextVar, object] = {}
+            previous_values: dict[ContextVar[Any], Any] = {}
+            tokens: dict[ContextVar[Any], Token[Any]] = {}
 
             # Restore ALL context values before any await and capture previous state
             # This is needed to propagate context across async generator boundaries
@@ -35,7 +37,7 @@ def preserve_contexts_async_generator[T](
                     previous_values[context_var] = _MISSING
                 tokens[context_var] = context_var.set(initial_context_values[context_var.name])
 
-            def _restore_context_var(context_var: ContextVar, *, _tokens=tokens, _prev=previous_values) -> None:
+            def _restore_context_var(context_var: ContextVar[Any], *, _tokens: dict[ContextVar[Any], Token[Any]] = tokens, _prev: dict[ContextVar[Any], Any] = previous_values) -> None:
                 token = _tokens.get(context_var)
                 previous_value = _prev.get(context_var, _MISSING)
                 if token is not None:

--- a/src/llama_stack/core/utils/dynamic.py
+++ b/src/llama_stack/core/utils/dynamic.py
@@ -5,9 +5,10 @@
 # the root directory of this source tree.
 
 import importlib
+from typing import Any
 
 
-def instantiate_class_type(fully_qualified_name):
+def instantiate_class_type(fully_qualified_name: str) -> Any:
     """Import and return a class from its fully qualified module path.
 
     Args:

--- a/src/llama_stack/core/utils/exec.py
+++ b/src/llama_stack/core/utils/exec.py
@@ -5,6 +5,7 @@
 # the root directory of this source tree.
 
 import importlib
+import importlib.resources
 import os
 import signal
 import subprocess
@@ -17,7 +18,7 @@ from llama_stack.log import get_logger
 log = get_logger(name=__name__, category="core")
 
 
-def formulate_run_args(image_type: str, distro_name: str) -> list:
+def formulate_run_args(image_type: str, distro_name: str) -> list[str]:
     """Build the command-line arguments for starting a Llama Stack server.
 
     Args:
@@ -40,7 +41,7 @@ def formulate_run_args(image_type: str, distro_name: str) -> list:
 
     cprint(f"Using virtual environment: {env_name}", file=sys.stderr)
 
-    script = importlib.resources.files("llama_stack") / "core/start_stack.sh"
+    script = str(importlib.resources.files("llama_stack") / "core/start_stack.sh")
     run_args = [
         script,
         image_type,
@@ -50,7 +51,7 @@ def formulate_run_args(image_type: str, distro_name: str) -> list:
     return run_args
 
 
-def in_notebook():
+def in_notebook() -> bool:
     """Detect whether the current code is running inside a Jupyter notebook.
 
     Returns:

--- a/src/llama_stack/core/utils/prompt_for_config.py
+++ b/src/llama_stack/core/utils/prompt_for_config.py
@@ -18,7 +18,7 @@ from llama_stack.log import get_logger
 log = get_logger(name=__name__, category="core")
 
 
-def is_list_of_primitives(field_type):
+def is_list_of_primitives(field_type: Any) -> bool:
     """Check if a field type is a List of primitive types."""
     origin = get_origin(field_type)
     if origin is list or origin is list:
@@ -28,7 +28,7 @@ def is_list_of_primitives(field_type):
     return False
 
 
-def is_basemodel_without_fields(typ):
+def is_basemodel_without_fields(typ: Any) -> bool:
     """Check if a type is a Pydantic BaseModel subclass with no defined fields.
 
     Args:
@@ -40,7 +40,7 @@ def is_basemodel_without_fields(typ):
     return inspect.isclass(typ) and issubclass(typ, BaseModel) and len(typ.__fields__) == 0
 
 
-def can_recurse(typ):
+def can_recurse(typ: Any) -> bool:
     """Check if a type is a Pydantic BaseModel subclass with fields that can be recursively prompted.
 
     Args:
@@ -52,19 +52,19 @@ def can_recurse(typ):
     return inspect.isclass(typ) and issubclass(typ, BaseModel) and len(typ.__fields__) > 0
 
 
-def get_literal_values(field):
+def get_literal_values(field: FieldInfo) -> tuple[Any, ...] | None:
     """Extract literal values from a field if it's a Literal type."""
     if get_origin(field.annotation) is Literal:
         return get_args(field.annotation)
     return None
 
 
-def is_optional(field_type):
+def is_optional(field_type: Any) -> bool:
     """Check if a field type is Optional."""
     return get_origin(field_type) is Union and type(None) in get_args(field_type)
 
 
-def get_non_none_type(field_type):
+def get_non_none_type(field_type: Any) -> Any:
     """Get the non-None type from an Optional type."""
     return next(arg for arg in get_args(field_type) if arg is not type(None))
 
@@ -88,7 +88,7 @@ def manually_validate_field(model: type[BaseModel], field_name: str, value: Any)
     return value
 
 
-def is_discriminated_union(typ) -> bool:
+def is_discriminated_union(typ: Any) -> bool:
     """Check if a type or FieldInfo represents a discriminated union.
 
     Args:
@@ -107,10 +107,10 @@ def is_discriminated_union(typ) -> bool:
 
 
 def prompt_for_discriminated_union(
-    field_name,
-    typ,
-    existing_value,
-):
+    field_name: str,
+    typ: Any,
+    existing_value: Any,
+) -> BaseModel:
     """Interactively prompt the user to select and configure a discriminated union variant.
 
     Args:
@@ -183,7 +183,7 @@ def prompt_for_config(config_type: type[BaseModel], existing_config: BaseModel |
     config_data = {}
 
     for field_name, field in config_type.__fields__.items():
-        field_type = field.annotation
+        field_type: Any = field.annotation
         existing_value = getattr(existing_config, field_name) if existing_config else None
         if existing_value:
             default_value = existing_value
@@ -196,7 +196,7 @@ def prompt_for_config(config_type: type[BaseModel], existing_config: BaseModel |
             continue
 
         # Skip fields with no type annotations
-        if is_basemodel_without_fields(field_type):
+        if field_type is not None and is_basemodel_without_fields(field_type):
             config_data[field_name] = field_type()
             continue
 
@@ -207,7 +207,7 @@ def prompt_for_config(config_type: type[BaseModel], existing_config: BaseModel |
                 user_input = input(prompt + " ")
                 try:
                     value = field_type[user_input]
-                    validated_value = manually_validate_field(config_type, field, value)
+                    validated_value = manually_validate_field(config_type, field_name, value)
                     config_data[field_name] = validated_value
                     break
                 except KeyError:
@@ -237,7 +237,7 @@ def prompt_for_config(config_type: type[BaseModel], existing_config: BaseModel |
                 nested_type,
                 existing_value,
             )
-        elif can_recurse(field_type):
+        elif field_type is not None and can_recurse(field_type):
             log.info(f"\nEntering sub-configuration for {field_name}:")
             config_data[field_name] = prompt_for_config(
                 field_type,
@@ -309,8 +309,10 @@ def prompt_for_config(config_type: type[BaseModel], existing_config: BaseModel |
                             import ast
 
                             value = field_type(**ast.literal_eval(user_input))
-                        else:
+                        elif field_type is not None:
                             value = field_type(user_input)
+                        else:
+                            value = user_input
 
                     except ValueError:
                         log.error(f"Invalid input. Expected type: {getattr(field_type, '__name__', str(field_type))}")

--- a/src/llama_stack/core/utils/serialize.py
+++ b/src/llama_stack/core/utils/serialize.py
@@ -7,14 +7,15 @@
 import json
 from datetime import datetime
 from enum import Enum
+from typing import Any
 
 
 class EnumEncoder(json.JSONEncoder):
     """JSON encoder that serializes Enum values and datetime objects."""
 
-    def default(self, obj):
-        if isinstance(obj, Enum):
-            return obj.value
-        elif isinstance(obj, datetime):
-            return obj.isoformat()
-        return super().default(obj)
+    def default(self, o: Any) -> Any:
+        if isinstance(o, Enum):
+            return o.value
+        elif isinstance(o, datetime):
+            return o.isoformat()
+        return super().default(o)

--- a/src/llama_stack/telemetry/__init__.py
+++ b/src/llama_stack/telemetry/__init__.py
@@ -17,7 +17,7 @@ from llama_stack.log import get_logger
 logger = get_logger(__name__, category="telemetry")
 
 
-def setup_telemetry():
+def setup_telemetry() -> None:
     """Initialize OpenTelemetry metrics exporter if configured via environment.
 
     This function checks for OTEL_EXPORTER_OTLP_ENDPOINT and configures the


### PR DESCRIPTION
## Summary
- Adds parameter and return type annotations to 14 core server lifecycle files
- All files pass `ty check` with zero errors (only 3 deprecation warnings for pre-existing `parse_obj_as` usage)
- All 288 core unit tests pass

## Changes
- `core/admin.py`, `core/inspect.py`, `core/providers.py`: Annotate `get_provider_impl(config, deps)` with proper types
- `core/client.py`: Type annotations for `get_client_impl`, `create_api_client_class`, helper functions; suppress `__signature__` attr
- `core/utils/context.py`: Proper `Token[Any]` types for contextvars
- `core/utils/dynamic.py`: Return `Any` from `instantiate_class_type` 
- `core/utils/prompt_for_config.py`: Add types to all functions, fix null safety, fix wrong arg to `manually_validate_field`
- `core/utils/serialize.py`: Fix `EnumEncoder.default` signature to match parent class
- `core/utils/exec.py`: Add `importlib.resources` import, fix `Traversable` to `str` conversion
- `core/stack.py`: Add `cast()` for dict subscripting, fix `distro_name` null handling, add return types
- `core/store/registry.py`: No changes needed (already typed)
- `core/task.py`: No changes needed (already typed)
- `core/testing_context.py`: Add `Token` types for return values
- `telemetry/__init__.py`: Add `-> None` return type

## Test plan
- [x] `ty check` on all 14 files passes with zero errors
- [x] `uv run pytest tests/unit/core/ tests/unit/distribution/ -v` — 288 tests pass

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)