### PR TITLE
feat: type-check remote inference providers (bedrock, nvidia, oci, passthrough, runpod, watsonx)

### DIFF
--- a/src/llama_stack/providers/remote/inference/bedrock/__init__.py
+++ b/src/llama_stack/providers/remote/inference/bedrock/__init__.py
@@ -3,10 +3,14 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
+from typing import Any
+
+from llama_stack_api import Api
+
 from .config import BedrockConfig
 
 
-async def get_adapter_impl(config: BedrockConfig, _deps):
+async def get_adapter_impl(config: BedrockConfig, _deps: dict[Api, Any]) -> Any:
     from .bedrock import BedrockInferenceAdapter
 
     assert isinstance(config, BedrockConfig), f"Unexpected config type: {type(config)}"

--- a/src/llama_stack/providers/remote/inference/nvidia/__init__.py
+++ b/src/llama_stack/providers/remote/inference/nvidia/__init__.py
@@ -4,12 +4,14 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-from llama_stack_api import Inference
+from typing import Any
+
+from llama_stack_api import Api
 
 from .config import NVIDIAConfig
 
 
-async def get_adapter_impl(config: NVIDIAConfig, _deps) -> Inference:
+async def get_adapter_impl(config: NVIDIAConfig, _deps: dict[Api, Any]) -> Any:
     # import dynamically so `llama stack list-deps` does not fail due to missing dependencies
     from .nvidia import NVIDIAInferenceAdapter
 

--- a/src/llama_stack/providers/remote/inference/nvidia/config.py
+++ b/src/llama_stack/providers/remote/inference/nvidia/config.py
@@ -46,7 +46,7 @@ class NVIDIAConfig(RemoteInferenceProviderConfig):
     URL of your running NVIDIA NIM and do not need to set the api_key.
     """
 
-    base_url: HttpUrl | None = Field(
+    base_url: HttpUrl | None = Field(  # ty: ignore[invalid-assignment]  # Pydantic coerces str from default_factory to HttpUrl
         default_factory=lambda: os.getenv("NVIDIA_BASE_URL", "https://integrate.api.nvidia.com/v1"),
         description="A base url for accessing the NVIDIA NIM",
     )
@@ -66,7 +66,7 @@ class NVIDIAConfig(RemoteInferenceProviderConfig):
     @classmethod
     def sample_run_config(
         cls,
-        base_url: HttpUrl | None = "${env.NVIDIA_BASE_URL:=https://integrate.api.nvidia.com/v1}",
+        base_url: str | None = "${env.NVIDIA_BASE_URL:=https://integrate.api.nvidia.com/v1}",
         api_key: str = "${env.NVIDIA_API_KEY:=}",
         **kwargs,
     ) -> dict[str, Any]:

--- a/src/llama_stack/providers/remote/inference/nvidia/nvidia.py
+++ b/src/llama_stack/providers/remote/inference/nvidia/nvidia.py
@@ -30,6 +30,7 @@ class NVIDIAInferenceAdapter(OpenAIMixin):
     """Inference adapter for NVIDIA NIM models and services."""
 
     config: NVIDIAConfig
+    __provider_id__: str = ""  # injected at runtime by routing table
 
     provider_data_api_key_field: str = "nvidia_api_key"
 
@@ -54,7 +55,7 @@ class NVIDIAInferenceAdapter(OpenAIMixin):
                     "API key is required for hosted NVIDIA NIM. Either provide an API key or use a self-hosted NIM."
                 )
 
-    def get_api_key(self) -> str:
+    def get_api_key(self) -> str | None:
         """
         Get the API key for OpenAI mixin.
 
@@ -96,7 +97,7 @@ class NVIDIAInferenceAdapter(OpenAIMixin):
         """
         if identifier in self.config.rerank_model_to_url:
             return Model(
-                provider_id=self.__provider_id__,  # type: ignore[attr-defined]
+                provider_id=self.__provider_id__,
                 provider_resource_id=identifier,
                 identifier=identifier,
                 model_type=ModelType.rerank,

--- a/src/llama_stack/providers/remote/inference/oci/__init__.py
+++ b/src/llama_stack/providers/remote/inference/oci/__init__.py
@@ -4,12 +4,14 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-from llama_stack_api import InferenceProvider
+from typing import Any
+
+from llama_stack_api import Api
 
 from .config import OCIConfig
 
 
-async def get_adapter_impl(config: OCIConfig, _deps) -> InferenceProvider:
+async def get_adapter_impl(config: OCIConfig, _deps: dict[Api, Any]) -> Any:
     from .oci import OCIInferenceAdapter
 
     adapter = OCIInferenceAdapter(config=config)

--- a/src/llama_stack/providers/remote/inference/oci/auth.py
+++ b/src/llama_stack/providers/remote/inference/oci/auth.py
@@ -48,7 +48,7 @@ class HttpxOciAuth(httpx.Auth):
         prepared_request = req.prepare()
 
         # Sign the request using the OCI Signer
-        self.signer.do_request_sign(prepared_request)  # type: ignore
+        self.signer.do_request_sign(prepared_request)  # ty: ignore[missing-argument]  # oci SDK signer type stubs are incomplete
 
         # Update the original HTTPX request with the signed headers
         request.headers.update(prepared_request.headers)
@@ -68,7 +68,7 @@ class OciUserPrincipalAuth(HttpxOciAuth):
 
     def __init__(self, config_file: str = DEFAULT_LOCATION, profile_name: str = DEFAULT_PROFILE):
         config = oci.config.from_file(config_file, profile_name)
-        oci.config.validate_config(config)  # type: ignore
+        oci.config.validate_config(config)
         key_content = ""
         with open(config["key_file"]) as f:
             key_content = f.read()
@@ -78,6 +78,6 @@ class OciUserPrincipalAuth(HttpxOciAuth):
             user=config["user"],
             fingerprint=config["fingerprint"],
             private_key_file_location=config.get("key_file"),
-            pass_phrase="none",  # type: ignore
+            pass_phrase="none",
             private_key_content=key_content,
         )

--- a/src/llama_stack/providers/remote/inference/oci/oci.py
+++ b/src/llama_stack/providers/remote/inference/oci/oci.py
@@ -34,6 +34,7 @@ class OCIInferenceAdapter(OpenAIMixin):
     """Inference adapter for Oracle Cloud Infrastructure Generative AI."""
 
     config: OCIConfig
+    __provider_id__: str = ""  # injected at runtime by routing table
 
     embedding_models: list[str] = []
 
@@ -152,13 +153,13 @@ class OCIInferenceAdapter(OpenAIMixin):
         """
         if identifier in self.embedding_models:
             return Model(
-                provider_id=self.__provider_id__,  # type: ignore[attr-defined]
+                provider_id=self.__provider_id__,
                 provider_resource_id=identifier,
                 identifier=identifier,
                 model_type=ModelType.embedding,
             )
         return Model(
-            provider_id=self.__provider_id__,  # type: ignore[attr-defined]
+            provider_id=self.__provider_id__,
             provider_resource_id=identifier,
             identifier=identifier,
             model_type=ModelType.llm,

--- a/src/llama_stack/providers/remote/inference/passthrough/__init__.py
+++ b/src/llama_stack/providers/remote/inference/passthrough/__init__.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+from typing import Any
+
 from pydantic import BaseModel, ConfigDict, HttpUrl, SecretStr
 
 from .config import PassthroughImplConfig
@@ -24,7 +26,7 @@ class PassthroughProviderDataValidator(BaseModel):
     passthrough_api_key: SecretStr | None = None
 
 
-async def get_adapter_impl(config: PassthroughImplConfig, _deps):
+async def get_adapter_impl(config: PassthroughImplConfig, _deps: dict[str, Any]) -> Any:
     from .passthrough import PassthroughInferenceAdapter
 
     if not isinstance(config, PassthroughImplConfig):

--- a/src/llama_stack/providers/remote/inference/passthrough/config.py
+++ b/src/llama_stack/providers/remote/inference/passthrough/config.py
@@ -53,7 +53,7 @@ class PassthroughImplConfig(RemoteInferenceProviderConfig):
     @classmethod
     def sample_run_config(
         cls,
-        base_url: HttpUrl | None = "${env.PASSTHROUGH_URL}",
+        base_url: str | None = "${env.PASSTHROUGH_URL}",
         api_key: str = "${env.PASSTHROUGH_API_KEY:=}",
         forward_headers: dict[str, str] | None = None,
         extra_blocked_headers: list[str] | None = None,

--- a/src/llama_stack/providers/remote/inference/passthrough/passthrough.py
+++ b/src/llama_stack/providers/remote/inference/passthrough/passthrough.py
@@ -32,6 +32,8 @@ logger = get_logger(__name__, category="inference")
 class PassthroughInferenceAdapter(NeedsRequestProviderData, Inference):
     """Inference adapter that forwards requests to any OpenAI-compatible endpoint."""
 
+    __provider_id__: str = ""  # injected at runtime by routing table
+
     def __init__(self, config: PassthroughImplConfig) -> None:
         self.config = config
 
@@ -60,11 +62,12 @@ class PassthroughInferenceAdapter(NeedsRequestProviderData, Inference):
             custom_metadata = getattr(model_data, "custom_metadata", {}) or {}
 
             # Prefix identifier with provider ID for local registry
-            local_identifier = f"{self.__provider_id__}/{downstream_model_id}"
+            provider_id: str = self.__provider_id__
+            local_identifier = f"{provider_id}/{downstream_model_id}"
 
             model = Model(
                 identifier=local_identifier,
-                provider_id=self.__provider_id__,
+                provider_id=provider_id,
                 provider_resource_id=downstream_model_id,
                 model_type=custom_metadata.get("model_type", "llm"),
                 metadata=custom_metadata,
@@ -180,4 +183,4 @@ class PassthroughInferenceAdapter(NeedsRequestProviderData, Inference):
         client = self._get_openai_client()
         request_params = params.model_dump(exclude_none=True)
         response = await client.embeddings.create(**request_params)
-        return response  # type: ignore
+        return response  # type: ignore[return-value]  # ty: ignore[invalid-return-type]  # OpenAI SDK returns compatible type

--- a/src/llama_stack/providers/remote/inference/runpod/__init__.py
+++ b/src/llama_stack/providers/remote/inference/runpod/__init__.py
@@ -4,10 +4,14 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+from typing import Any
+
+from llama_stack_api import Api
+
 from .config import RunpodImplConfig
 
 
-async def get_adapter_impl(config: RunpodImplConfig, _deps):
+async def get_adapter_impl(config: RunpodImplConfig, _deps: dict[Api, Any]) -> Any:
     from .runpod import RunpodInferenceAdapter
 
     assert isinstance(config, RunpodImplConfig), f"Unexpected config type: {type(config)}"

--- a/src/llama_stack/providers/remote/inference/watsonx/__init__.py
+++ b/src/llama_stack/providers/remote/inference/watsonx/__init__.py
@@ -4,10 +4,14 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+from typing import Any
+
+from llama_stack_api import Api
+
 from .config import WatsonXConfig
 
 
-async def get_adapter_impl(config: WatsonXConfig, _deps):
+async def get_adapter_impl(config: WatsonXConfig, _deps: dict[Api, Any]) -> Any:
     # import dynamically so the import is used only when it is needed
     from .watsonx import WatsonXInferenceAdapter
 

--- a/src/llama_stack/providers/remote/inference/watsonx/config.py
+++ b/src/llama_stack/providers/remote/inference/watsonx/config.py
@@ -27,7 +27,7 @@ class WatsonXProviderDataValidator(BaseModel):
 class WatsonXConfig(RemoteInferenceProviderConfig):
     """Configuration for the IBM WatsonX inference provider."""
 
-    base_url: HttpUrl | None = Field(
+    base_url: HttpUrl | None = Field(  # ty: ignore[invalid-assignment]  # Pydantic coerces str from default_factory to HttpUrl
         default_factory=lambda: os.getenv("WATSONX_BASE_URL", "https://us-south.ml.cloud.ibm.com"),
         description="A base url for accessing the watsonx.ai",
     )

--- a/src/llama_stack/providers/remote/inference/watsonx/watsonx.py
+++ b/src/llama_stack/providers/remote/inference/watsonx/watsonx.py
@@ -35,6 +35,9 @@ WATSONX_API_VERSION = "2023-10-25"
 class WatsonXInferenceAdapter(OpenAIMixin):
     """Inference adapter for IBM WatsonX AI platform."""
 
+    config: WatsonXConfig  # narrowing from base RemoteInferenceProviderConfig
+    __provider_id__: str = ""  # injected at runtime by routing table
+
     _model_cache: dict[str, Model] = {}
 
     provider_data_api_key_field: str = "watsonx_api_key"


### PR DESCRIPTION
## Summary
- Add type annotations to all `get_adapter_impl` functions across 6 remote inference providers
- Declare `__provider_id__: str` as class attribute on adapter classes (runtime-injected by routing table)
- Fix `get_api_key` return type on `NVIDIAInferenceAdapter` (`str` → `str | None`)
- Add `ty: ignore` for Pydantic `Field` assignments where ty incorrectly infers `dataclasses.Field` type
- Fix bare `# type: ignore` comments to include error codes
- Fix `sample_run_config` parameter types (`HttpUrl | None` → `str | None` for template strings)

## Verification
- `ty check` passes with zero errors on all 6 provider directories
- 1592 unit tests pass (pre-existing import errors in unrelated test modules excluded)

## Build times
- ty check: 0.23s
- pytest (unit): 40.8s

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)